### PR TITLE
Allow client to specify an adapter to build an auth ctx from request

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -1,0 +1,19 @@
+'use strict';
+
+function swatchCtx(options) {
+  return {
+    authAdapter: initAuthCtx,
+  };
+
+  function initAuthCtx(koaCtx) {
+    try {
+      return Promise.resolve(
+        options.authAdapter(koaCtx)
+      )
+    } catch (error) {
+      return Promise.reject(error);
+    }
+  };
+}
+
+module.exports = swatchCtx;

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -7,6 +7,7 @@ function defaults(options) {
   return {
     verbs: defaultVerbs(options && options.verbs),
     prefix: defaultPrefix(options && options.prefix),
+    authAdapter: defaultAuthAdapter(options && options.authAdapter),
   };
 }
 
@@ -27,6 +28,18 @@ function defaultVerbs(requested) {
 
 function defaultPrefix(prefix) {
   return (prefix && `/${prefix}/`) || '/';
+}
+
+function defaultAuthAdapter(authAdapter) {
+  if (authAdapter && !(typeof authAdapter === 'function')) {
+    throw TypeError('function required for authAdapter');
+  }
+
+  function noopAuthAdapter() {
+    return {};
+  }
+
+  return authAdapter || noopAuthAdapter;
 }
 
 module.exports = defaults;

--- a/lib/expose.js
+++ b/lib/expose.js
@@ -5,18 +5,26 @@ const Router = require('koa-router');
 const defaults = require('./defaults');
 const handlers = require('./handlers');
 
-function expose(app, model, options) {
+function expose(app, methods, options) {
   const router = new Router();
 
   options = defaults(options);
-  model.forEach(addMethod);
+
+  const swatchCtx = {
+    authAdapter: options.authAdapter,
+  };
+
+  methods.forEach(addMethod);
 
   function addMethod(method) {
     options.verbs.forEach(addRoute);
 
     function addRoute(verb) {
       verb = verb.trim();
-      router[verb](`${options.prefix}${method.name}`, handlers[verb](method));
+      const handler = handlers[verb](swatchCtx, method);
+      const path = `${options.prefix}${method.name}`;
+
+      router[verb](path, handler);
     }
   }
 

--- a/lib/expose.js
+++ b/lib/expose.js
@@ -4,15 +4,13 @@ const Router = require('koa-router');
 
 const defaults = require('./defaults');
 const handlers = require('./handlers');
+const swatchCtx = require('./context');
 
 function expose(app, methods, options) {
-  const router = new Router();
-
   options = defaults(options);
 
-  const swatchCtx = {
-    authAdapter: options.authAdapter,
-  };
+  const router = new Router();
+  const ctx = swatchCtx(options);
 
   methods.forEach(addMethod);
 
@@ -21,7 +19,7 @@ function expose(app, methods, options) {
 
     function addRoute(verb) {
       verb = verb.trim();
-      const handler = handlers[verb](swatchCtx, method);
+      const handler = handlers[verb](ctx, method);
       const path = `${options.prefix}${method.name}`;
 
       router[verb](path, handler);

--- a/lib/handlers/get.js
+++ b/lib/handlers/get.js
@@ -2,11 +2,11 @@
 
 const handler = require('./handler');
 
-function get(info) {
+function get(swatchCtx, method) {
   return getHandler;
 
   function getHandler(ctx, next) {
-    return handler(ctx, ctx.query, info);
+    return handler(ctx, ctx.query, method);
   }
 }
 

--- a/lib/handlers/get.js
+++ b/lib/handlers/get.js
@@ -5,8 +5,8 @@ const handler = require('./handler');
 function get(swatchCtx, method) {
   return getHandler;
 
-  function getHandler(ctx, next) {
-    return handler(ctx, ctx.query, method);
+  function getHandler(koaCtx, next) {
+    return handler(swatchCtx, koaCtx, koaCtx.query, method);
   }
 }
 

--- a/lib/handlers/handler.js
+++ b/lib/handlers/handler.js
@@ -8,7 +8,7 @@ function handler(swatchCtx, koaCtx, params, method) {
       return swatchCtx.authAdapter(koaCtx);
     }).then(auth => {
       // Run any middleware registered for endpoint
-      const middleware = method.middleware || [];
+      const middleware = method.middleware;
       middleware.forEach(fn => fn(koaCtx, auth));
 
       return params;

--- a/lib/handlers/handler.js
+++ b/lib/handlers/handler.js
@@ -1,10 +1,10 @@
 'use strict';
 
-function handler(ctx, params, info) {
+function handler(ctx, params, method) {
   return Promise
     .resolve(params)
     .then(args => {
-      return info.handle(args);
+      return method.handle(args);
     }).then(result => {
       ctx.body = {
         ok: true,

--- a/lib/handlers/handler.js
+++ b/lib/handlers/handler.js
@@ -1,17 +1,27 @@
 'use strict';
 
-function handler(ctx, params, method) {
+function handler(swatchCtx, koaCtx, params, method) {
   return Promise
-    .resolve(params)
-    .then(args => {
+    .resolve()
+    .then(() => {
+      // Extract auth/credentials from KOA request ctx
+      return swatchCtx.authAdapter(koaCtx);
+    }).then(auth => {
+      // Run any middleware registered for endpoint
+      const middleware = method.middleware || [];
+      middleware.forEach(fn => fn(koaCtx, auth));
+
+      return params;
+    }).then(args => {
+      // Pass args into handler and process request
       return method.handle(args);
     }).then(result => {
-      ctx.body = {
+      koaCtx.body = {
         ok: true,
         result,
       };
     }).catch(error => {
-      ctx.body = {
+      koaCtx.body = {
         ok: false,
         error: (error && error.message) || error,
       };

--- a/lib/handlers/handler.js
+++ b/lib/handlers/handler.js
@@ -1,20 +1,23 @@
 'use strict';
 
-function handler(swatchCtx, koaCtx, params, method) {
-  return Promise
-    .resolve()
-    .then(() => {
-      // Extract auth/credentials from KOA request ctx
-      return swatchCtx.authAdapter(koaCtx);
-    }).then(auth => {
-      // Run any middleware registered for endpoint
-      const middleware = method.middleware;
-      middleware.forEach(fn => fn(koaCtx, auth));
+const compose = require('koa-compose');
 
-      return params;
-    }).then(args => {
-      // Pass args into handler and process request
-      return method.handle(args);
+function handler(swatchCtx, koaCtx, params, method) {
+  // Extract auth/credentials from KOA request ctx
+  return swatchCtx.authAdapter(koaCtx)
+    .then(auth => {
+      // Add swatchJs object on the parent context
+      koaCtx.swatchJs = {
+        auth,
+        params,
+      };
+
+      // Run any middleware registered for endpoint
+      return compose(method.middleware)(koaCtx);
+
+    }).then(() => {
+      // Finally run the handler with caller args
+      return method.handle(koaCtx.swatchJs.params);
     }).then(result => {
       koaCtx.body = {
         ok: true,

--- a/lib/handlers/post.js
+++ b/lib/handlers/post.js
@@ -5,8 +5,8 @@ const handler = require('./handler');
 function post(swatchCtx, method) {
   return postHandler;
 
-  function postHandler(ctx, next) {
-    return handler(ctx, ctx.request.body, method);
+  function postHandler(koaCtx, next) {
+    return handler(swatchCtx, koaCtx, koaCtx.request.body, method);
   }
 }
 

--- a/lib/handlers/post.js
+++ b/lib/handlers/post.js
@@ -2,11 +2,11 @@
 
 const handler = require('./handler');
 
-function post(info) {
+function post(swatchCtx, method) {
   return postHandler;
 
   function postHandler(ctx, next) {
-    return handler(ctx, ctx.request.body, info);
+    return handler(ctx, ctx.request.body, method);
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "swatchjs-koa",
-  "version": "0.1.2",
+  "version": "0.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -38,9 +38,9 @@
       "dev": true
     },
     "chai": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.0.2.tgz",
-      "integrity": "sha1-L3MnxN5vOF3XeHmZ4qsCaXoyuDs=",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.0.tgz",
+      "integrity": "sha1-MxoDkbVcOvh0CunDt0WLwcOAXm0=",
       "dev": true,
       "requires": {
         "assertion-error": "1.0.2",
@@ -73,11 +73,11 @@
       "dev": true
     },
     "debug": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
-      "integrity": "sha1-vFlryr52F/Edn6FTYe3tVgi4SZs=",
+      "version": "2.6.8",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
       "requires": {
-        "ms": "0.7.2"
+        "ms": "2.0.0"
       }
     },
     "deep-eql": {
@@ -129,6 +129,11 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "function-arguments": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/function-arguments/-/function-arguments-1.0.8.tgz",
+      "integrity": "sha1-uaAdrKa4lO/4w9NoQDde2WNqbA8="
+    },
     "get-func-name": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
@@ -167,6 +172,11 @@
       "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
       "dev": true
     },
+    "hoek": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
+      "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
+    },
     "http-errors": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.1.tgz",
@@ -198,6 +208,27 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
       "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
     },
+    "isemail": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-2.2.1.tgz",
+      "integrity": "sha1-A1PT2aYpUQgMJiwqoKQrjqjp4qY="
+    },
+    "items": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/items/-/items-2.1.1.tgz",
+      "integrity": "sha1-i9FtnIOxlSneWuoyGsqtp4NkoZg="
+    },
+    "joi": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz",
+      "integrity": "sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==",
+      "requires": {
+        "hoek": "4.2.0",
+        "isemail": "2.2.1",
+        "items": "2.1.1",
+        "topo": "2.0.2"
+      }
+    },
     "json3": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
@@ -217,7 +248,7 @@
       "resolved": "https://registry.npmjs.org/koa-router/-/koa-router-7.2.1.tgz",
       "integrity": "sha1-tApKs8attLQIld69AKnGQDBOMDk=",
       "requires": {
-        "debug": "2.6.0",
+        "debug": "2.6.8",
         "http-errors": "1.6.1",
         "koa-compose": "3.2.1",
         "methods": "1.1.2",
@@ -344,12 +375,29 @@
         "lodash.create": "3.1.1",
         "mkdirp": "0.5.1",
         "supports-color": "3.1.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
+          "integrity": "sha1-vFlryr52F/Edn6FTYe3tVgi4SZs=",
+          "dev": true,
+          "requires": {
+            "ms": "0.7.2"
+          }
+        },
+        "ms": {
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
+          "dev": true
+        }
       }
     },
     "ms": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-      "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "native-promise-only": {
       "version": "0.8.1",
@@ -363,1602 +411,1602 @@
       "integrity": "sha1-DCi8ZpqFFiFwm/eghQMDS+44ErY=",
       "dev": true,
       "requires": {
-        "archy": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-        "arrify": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-        "caching-transform": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz",
-        "convert-source-map": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
-        "debug-log": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
-        "default-require-extensions": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
-        "find-cache-dir": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
-        "find-up": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-        "foreground-child": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
-        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-        "istanbul-lib-coverage": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
-        "istanbul-lib-hook": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.0.7.tgz",
-        "istanbul-lib-instrument": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.3.tgz",
-        "istanbul-lib-report": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
-        "istanbul-lib-source-maps": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.1.tgz",
-        "istanbul-reports": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
-        "md5-hex": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
-        "merge-source-map": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.0.4.tgz",
-        "micromatch": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-        "resolve-from": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-        "signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-        "spawn-wrap": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.3.7.tgz",
-        "test-exclude": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.1.1.tgz",
-        "yargs": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
-        "yargs-parser": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz"
+        "archy": "1.0.0",
+        "arrify": "1.0.1",
+        "caching-transform": "1.0.1",
+        "convert-source-map": "1.5.0",
+        "debug-log": "1.0.1",
+        "default-require-extensions": "1.0.0",
+        "find-cache-dir": "0.1.1",
+        "find-up": "2.1.0",
+        "foreground-child": "1.5.6",
+        "glob": "7.1.2",
+        "istanbul-lib-coverage": "1.1.1",
+        "istanbul-lib-hook": "1.0.7",
+        "istanbul-lib-instrument": "1.7.3",
+        "istanbul-lib-report": "1.1.1",
+        "istanbul-lib-source-maps": "1.2.1",
+        "istanbul-reports": "1.1.1",
+        "md5-hex": "1.3.0",
+        "merge-source-map": "1.0.4",
+        "micromatch": "2.3.11",
+        "mkdirp": "0.5.1",
+        "resolve-from": "2.0.0",
+        "rimraf": "2.6.1",
+        "signal-exit": "3.0.2",
+        "spawn-wrap": "1.3.7",
+        "test-exclude": "4.1.1",
+        "yargs": "8.0.2",
+        "yargs-parser": "5.0.0"
       },
       "dependencies": {
         "align-text": {
-          "version": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-          "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+          "version": "0.1.4",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-            "longest": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-            "repeat-string": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+            "kind-of": "3.2.2",
+            "longest": "1.0.1",
+            "repeat-string": "1.6.1"
           }
         },
         "amdefine": {
-          "version": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-          "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+          "version": "1.0.1",
+          "bundled": true,
           "dev": true
         },
         "ansi-regex": {
-          "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "version": "2.1.1",
+          "bundled": true,
           "dev": true
         },
         "ansi-styles": {
-          "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "version": "2.2.1",
+          "bundled": true,
           "dev": true
         },
         "append-transform": {
-          "version": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
-          "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
+          "version": "0.4.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "default-require-extensions": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz"
+            "default-require-extensions": "1.0.0"
           }
         },
         "archy": {
-          "version": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-          "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+          "version": "1.0.0",
+          "bundled": true,
           "dev": true
         },
         "arr-diff": {
-          "version": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+          "version": "2.0.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "arr-flatten": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz"
+            "arr-flatten": "1.0.3"
           }
         },
         "arr-flatten": {
-          "version": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
-          "integrity": "sha1-onTthawIhJtr14R8RYB0XcUa37E=",
+          "version": "1.0.3",
+          "bundled": true,
           "dev": true
         },
         "array-unique": {
-          "version": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+          "version": "0.2.1",
+          "bundled": true,
           "dev": true
         },
         "arrify": {
-          "version": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+          "version": "1.0.1",
+          "bundled": true,
           "dev": true
         },
         "async": {
-          "version": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "version": "1.5.2",
+          "bundled": true,
           "dev": true
         },
         "babel-code-frame": {
-          "version": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-          "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
+          "version": "6.22.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-            "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-            "js-tokens": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
+            "chalk": "1.1.3",
+            "esutils": "2.0.2",
+            "js-tokens": "3.0.1"
           }
         },
         "babel-generator": {
-          "version": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.25.0.tgz",
-          "integrity": "sha1-M6GvcNXyiQrrRlpKd5PB32qeqfw=",
+          "version": "6.25.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "babel-messages": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-            "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-            "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
-            "detect-indent": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-            "jsesc": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-            "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-            "trim-right": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
+            "babel-messages": "6.23.0",
+            "babel-runtime": "6.23.0",
+            "babel-types": "6.25.0",
+            "detect-indent": "4.0.0",
+            "jsesc": "1.3.0",
+            "lodash": "4.17.4",
+            "source-map": "0.5.6",
+            "trim-right": "1.0.1"
           }
         },
         "babel-messages": {
-          "version": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-          "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+          "version": "6.23.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+            "babel-runtime": "6.23.0"
           }
         },
         "babel-runtime": {
-          "version": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-          "integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs=",
+          "version": "6.23.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "core-js": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-            "regenerator-runtime": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+            "core-js": "2.4.1",
+            "regenerator-runtime": "0.10.5"
           }
         },
         "babel-template": {
-          "version": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
-          "integrity": "sha1-ZlJBFmt8KqTGGdceGSlpVSsQwHE=",
+          "version": "6.25.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-            "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
-            "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
-            "babylon": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz",
-            "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+            "babel-runtime": "6.23.0",
+            "babel-traverse": "6.25.0",
+            "babel-types": "6.25.0",
+            "babylon": "6.17.4",
+            "lodash": "4.17.4"
           }
         },
         "babel-traverse": {
-          "version": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
-          "integrity": "sha1-IldJfi/NGbie3BPEyROB+VEklvE=",
+          "version": "6.25.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "babel-code-frame": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-            "babel-messages": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-            "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-            "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
-            "babylon": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz",
-            "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-            "globals": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-            "invariant": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-            "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+            "babel-code-frame": "6.22.0",
+            "babel-messages": "6.23.0",
+            "babel-runtime": "6.23.0",
+            "babel-types": "6.25.0",
+            "babylon": "6.17.4",
+            "debug": "2.6.8",
+            "globals": "9.18.0",
+            "invariant": "2.2.2",
+            "lodash": "4.17.4"
           }
         },
         "babel-types": {
-          "version": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
-          "integrity": "sha1-cK+ySNVmDl0Y+BHZHIMDtUE0oY4=",
+          "version": "6.25.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-            "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-            "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-            "to-fast-properties": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+            "babel-runtime": "6.23.0",
+            "esutils": "2.0.2",
+            "lodash": "4.17.4",
+            "to-fast-properties": "1.0.3"
           }
         },
         "babylon": {
-          "version": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz",
-          "integrity": "sha1-Pot0AriNIsNCPhN6FXeIOxX/hpo=",
+          "version": "6.17.4",
+          "bundled": true,
           "dev": true
         },
         "balanced-match": {
-          "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+          "version": "1.0.0",
+          "bundled": true,
           "dev": true
         },
         "brace-expansion": {
-          "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-          "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+          "version": "1.1.8",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-            "concat-map": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+            "balanced-match": "1.0.0",
+            "concat-map": "0.0.1"
           }
         },
         "braces": {
-          "version": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+          "version": "1.8.5",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "expand-range": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-            "preserve": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-            "repeat-element": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
+            "expand-range": "1.8.2",
+            "preserve": "0.2.0",
+            "repeat-element": "1.1.2"
           }
         },
         "builtin-modules": {
-          "version": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-          "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+          "version": "1.1.1",
+          "bundled": true,
           "dev": true
         },
         "caching-transform": {
-          "version": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz",
-          "integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
+          "version": "1.0.1",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "md5-hex": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
-            "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-            "write-file-atomic": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz"
+            "md5-hex": "1.3.0",
+            "mkdirp": "0.5.1",
+            "write-file-atomic": "1.3.4"
           }
         },
         "camelcase": {
-          "version": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+          "version": "1.2.1",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "center-align": {
-          "version": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-          "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+          "version": "0.1.3",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "align-text": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-            "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
+            "align-text": "0.1.4",
+            "lazy-cache": "1.0.4"
           }
         },
         "chalk": {
-          "version": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "version": "1.1.3",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-            "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "has-ansi": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         },
         "cliui": {
-          "version": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+          "version": "2.1.0",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "center-align": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-            "right-align": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-            "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+            "center-align": "0.1.3",
+            "right-align": "0.1.3",
+            "wordwrap": "0.0.2"
           },
           "dependencies": {
             "wordwrap": {
-              "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-              "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+              "version": "0.0.2",
+              "bundled": true,
               "dev": true,
               "optional": true
             }
           }
         },
         "code-point-at": {
-          "version": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "version": "1.1.0",
+          "bundled": true,
           "dev": true
         },
         "commondir": {
-          "version": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-          "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+          "version": "1.0.1",
+          "bundled": true,
           "dev": true
         },
         "concat-map": {
-          "version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+          "version": "0.0.1",
+          "bundled": true,
           "dev": true
         },
         "convert-source-map": {
-          "version": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
-          "integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU=",
+          "version": "1.5.0",
+          "bundled": true,
           "dev": true
         },
         "core-js": {
-          "version": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-          "integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4=",
+          "version": "2.4.1",
+          "bundled": true,
           "dev": true
         },
         "cross-spawn": {
-          "version": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-          "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+          "version": "4.0.2",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "lru-cache": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-            "which": "https://registry.npmjs.org/which/-/which-1.2.14.tgz"
+            "lru-cache": "4.1.1",
+            "which": "1.2.14"
           }
         },
         "debug": {
-          "version": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "version": "2.6.8",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "ms": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+            "ms": "2.0.0"
           }
         },
         "debug-log": {
-          "version": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
-          "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
+          "version": "1.0.1",
+          "bundled": true,
           "dev": true
         },
         "decamelize": {
-          "version": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+          "version": "1.2.0",
+          "bundled": true,
           "dev": true
         },
         "default-require-extensions": {
-          "version": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
-          "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
+          "version": "1.0.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
+            "strip-bom": "2.0.0"
           }
         },
         "detect-indent": {
-          "version": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-          "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+          "version": "4.0.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "repeating": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz"
+            "repeating": "2.0.1"
           }
         },
         "error-ex": {
-          "version": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-          "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+          "version": "1.3.1",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "is-arrayish": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
+            "is-arrayish": "0.2.1"
           }
         },
         "escape-string-regexp": {
-          "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "version": "1.0.5",
+          "bundled": true,
           "dev": true
         },
         "esutils": {
-          "version": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-          "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+          "version": "2.0.2",
+          "bundled": true,
           "dev": true
         },
         "execa": {
-          "version": "https://registry.npmjs.org/execa/-/execa-0.5.1.tgz",
-          "integrity": "sha1-3j+4XLjW6RyFvLzrFkWBeFy1ezY=",
+          "version": "0.5.1",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "cross-spawn": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-            "get-stream": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
-            "is-stream": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-            "npm-run-path": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-            "p-finally": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-            "signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-            "strip-eof": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz"
+            "cross-spawn": "4.0.2",
+            "get-stream": "2.3.1",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
           }
         },
         "expand-brackets": {
-          "version": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+          "version": "0.1.5",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "is-posix-bracket": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
+            "is-posix-bracket": "0.1.1"
           }
         },
         "expand-range": {
-          "version": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-          "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+          "version": "1.8.2",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "fill-range": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz"
+            "fill-range": "2.2.3"
           }
         },
         "extglob": {
-          "version": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+          "version": "0.3.2",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+            "is-extglob": "1.0.0"
           }
         },
         "filename-regex": {
-          "version": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-          "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+          "version": "2.0.1",
+          "bundled": true,
           "dev": true
         },
         "fill-range": {
-          "version": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-          "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+          "version": "2.2.3",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "is-number": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-            "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-            "randomatic": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-            "repeat-element": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-            "repeat-string": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+            "is-number": "2.1.0",
+            "isobject": "2.1.0",
+            "randomatic": "1.1.7",
+            "repeat-element": "1.1.2",
+            "repeat-string": "1.6.1"
           }
         },
         "find-cache-dir": {
-          "version": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
-          "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
+          "version": "0.1.1",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "commondir": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-            "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-            "pkg-dir": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz"
+            "commondir": "1.0.1",
+            "mkdirp": "0.5.1",
+            "pkg-dir": "1.0.0"
           }
         },
         "find-up": {
-          "version": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "version": "2.1.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "locate-path": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz"
+            "locate-path": "2.0.0"
           }
         },
         "for-in": {
-          "version": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-          "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+          "version": "1.0.2",
+          "bundled": true,
           "dev": true
         },
         "for-own": {
-          "version": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-          "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+          "version": "0.1.5",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "for-in": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz"
+            "for-in": "1.0.2"
           }
         },
         "foreground-child": {
-          "version": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
-          "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
+          "version": "1.5.6",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "cross-spawn": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-            "signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
+            "cross-spawn": "4.0.2",
+            "signal-exit": "3.0.2"
           }
         },
         "fs.realpath": {
-          "version": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+          "version": "1.0.0",
+          "bundled": true,
           "dev": true
         },
         "get-caller-file": {
-          "version": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-          "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+          "version": "1.0.2",
+          "bundled": true,
           "dev": true
         },
         "get-stream": {
-          "version": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
-          "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
+          "version": "2.3.1",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-            "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+            "object-assign": "4.1.1",
+            "pinkie-promise": "2.0.1"
           }
         },
         "glob": {
-          "version": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "version": "7.1.2",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "glob-base": {
-          "version": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-          "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+          "version": "0.3.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "glob-parent": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-            "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
+            "glob-parent": "2.0.0",
+            "is-glob": "2.0.1"
           }
         },
         "glob-parent": {
-          "version": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-          "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+          "version": "2.0.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
+            "is-glob": "2.0.1"
           }
         },
         "globals": {
-          "version": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-          "integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo=",
+          "version": "9.18.0",
+          "bundled": true,
           "dev": true
         },
         "graceful-fs": {
-          "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+          "version": "4.1.11",
+          "bundled": true,
           "dev": true
         },
         "handlebars": {
-          "version": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
-          "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
+          "version": "4.0.10",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-            "optimist": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-            "uglify-js": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz"
+            "async": "1.5.2",
+            "optimist": "0.6.1",
+            "source-map": "0.4.4",
+            "uglify-js": "2.8.29"
           },
           "dependencies": {
             "source-map": {
-              "version": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-              "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+              "version": "0.4.4",
+              "bundled": true,
               "dev": true,
               "requires": {
-                "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
+                "amdefine": "1.0.1"
               }
             }
           }
         },
         "has-ansi": {
-          "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+          "version": "2.0.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+            "ansi-regex": "2.1.1"
           }
         },
         "has-flag": {
-          "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+          "version": "1.0.0",
+          "bundled": true,
           "dev": true
         },
         "hosted-git-info": {
-          "version": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.2.tgz",
-          "integrity": "sha1-AHa59GonBQbduq6lZJaJdGBhKmc=",
+          "version": "2.4.2",
+          "bundled": true,
           "dev": true
         },
         "imurmurhash": {
-          "version": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+          "version": "0.1.4",
+          "bundled": true,
           "dev": true
         },
         "inflight": {
-          "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+          "version": "1.0.6",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-            "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
           }
         },
         "inherits": {
-          "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "version": "2.0.3",
+          "bundled": true,
           "dev": true
         },
         "invariant": {
-          "version": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-          "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+          "version": "2.2.2",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "loose-envify": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz"
+            "loose-envify": "1.3.1"
           }
         },
         "invert-kv": {
-          "version": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-          "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+          "version": "1.0.0",
+          "bundled": true,
           "dev": true
         },
         "is-arrayish": {
-          "version": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-          "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+          "version": "0.2.1",
+          "bundled": true,
           "dev": true
         },
         "is-buffer": {
-          "version": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-          "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
+          "version": "1.1.5",
+          "bundled": true,
           "dev": true
         },
         "is-builtin-module": {
-          "version": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-          "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+          "version": "1.0.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "builtin-modules": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
+            "builtin-modules": "1.1.1"
           }
         },
         "is-dotfile": {
-          "version": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-          "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+          "version": "1.0.3",
+          "bundled": true,
           "dev": true
         },
         "is-equal-shallow": {
-          "version": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-          "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+          "version": "0.1.3",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "is-primitive": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
+            "is-primitive": "2.0.0"
           }
         },
         "is-extendable": {
-          "version": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-          "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+          "version": "0.1.1",
+          "bundled": true,
           "dev": true
         },
         "is-extglob": {
-          "version": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "version": "1.0.0",
+          "bundled": true,
           "dev": true
         },
         "is-finite": {
-          "version": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-          "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+          "version": "1.0.2",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+            "number-is-nan": "1.0.1"
           }
         },
         "is-fullwidth-code-point": {
-          "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "version": "1.0.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+            "number-is-nan": "1.0.1"
           }
         },
         "is-glob": {
-          "version": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "version": "2.0.1",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+            "is-extglob": "1.0.0"
           }
         },
         "is-number": {
-          "version": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-          "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+          "version": "2.1.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz"
+            "kind-of": "3.2.2"
           }
         },
         "is-posix-bracket": {
-          "version": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-          "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+          "version": "0.1.1",
+          "bundled": true,
           "dev": true
         },
         "is-primitive": {
-          "version": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-          "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+          "version": "2.0.0",
+          "bundled": true,
           "dev": true
         },
         "is-stream": {
-          "version": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+          "version": "1.1.0",
+          "bundled": true,
           "dev": true
         },
         "is-utf8": {
-          "version": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-          "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+          "version": "0.2.1",
+          "bundled": true,
           "dev": true
         },
         "isarray": {
-          "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "version": "1.0.0",
+          "bundled": true,
           "dev": true
         },
         "isexe": {
-          "version": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+          "version": "2.0.0",
+          "bundled": true,
           "dev": true
         },
         "isobject": {
-          "version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+          "version": "2.1.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+            "isarray": "1.0.0"
           }
         },
         "istanbul-lib-coverage": {
-          "version": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
-          "integrity": "sha1-c7+5mIhSmUFck9OKPprfeEp3qdo=",
+          "version": "1.1.1",
+          "bundled": true,
           "dev": true
         },
         "istanbul-lib-hook": {
-          "version": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.0.7.tgz",
-          "integrity": "sha1-3WYH8DB2V4/n1vKmMM8UO0m6zdw=",
+          "version": "1.0.7",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "append-transform": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz"
+            "append-transform": "0.4.0"
           }
         },
         "istanbul-lib-instrument": {
-          "version": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.3.tgz",
-          "integrity": "sha1-klsjkWPqvdaMxASPUsL6T4mez6c=",
+          "version": "1.7.3",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "babel-generator": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.25.0.tgz",
-            "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
-            "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
-            "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
-            "babylon": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz",
-            "istanbul-lib-coverage": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
-            "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
+            "babel-generator": "6.25.0",
+            "babel-template": "6.25.0",
+            "babel-traverse": "6.25.0",
+            "babel-types": "6.25.0",
+            "babylon": "6.17.4",
+            "istanbul-lib-coverage": "1.1.1",
+            "semver": "5.3.0"
           }
         },
         "istanbul-lib-report": {
-          "version": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
-          "integrity": "sha1-8OVfVmVf+jQiIIC3oM1HYOFAX8k=",
+          "version": "1.1.1",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "istanbul-lib-coverage": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
-            "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-            "path-parse": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
+            "istanbul-lib-coverage": "1.1.1",
+            "mkdirp": "0.5.1",
+            "path-parse": "1.0.5",
+            "supports-color": "3.2.3"
           },
           "dependencies": {
             "supports-color": {
-              "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-              "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+              "version": "3.2.3",
+              "bundled": true,
               "dev": true,
               "requires": {
-                "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+                "has-flag": "1.0.0"
               }
             }
           }
         },
         "istanbul-lib-source-maps": {
-          "version": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.1.tgz",
-          "integrity": "sha1-pv4ay6jOCO68Y45XLilNJnAIqgw=",
+          "version": "1.2.1",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-            "istanbul-lib-coverage": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
-            "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-            "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+            "debug": "2.6.8",
+            "istanbul-lib-coverage": "1.1.1",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.1",
+            "source-map": "0.5.6"
           }
         },
         "istanbul-reports": {
-          "version": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
-          "integrity": "sha1-BCvlyJ4XW8P4ZSPKqynAFOd/7k4=",
+          "version": "1.1.1",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "handlebars": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz"
+            "handlebars": "4.0.10"
           }
         },
         "js-tokens": {
-          "version": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
-          "integrity": "sha1-COnxMkhKLEWjCQfp3E1VZ7fxFNc=",
+          "version": "3.0.1",
+          "bundled": true,
           "dev": true
         },
         "jsesc": {
-          "version": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-          "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+          "version": "1.3.0",
+          "bundled": true,
           "dev": true
         },
         "kind-of": {
-          "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "version": "3.2.2",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+            "is-buffer": "1.1.5"
           }
         },
         "lazy-cache": {
-          "version": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-          "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+          "version": "1.0.4",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "lcid": {
-          "version": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-          "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+          "version": "1.0.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "invert-kv": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
+            "invert-kv": "1.0.0"
           }
         },
         "load-json-file": {
-          "version": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+          "version": "1.1.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-            "parse-json": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-            "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-            "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-            "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
           }
         },
         "locate-path": {
-          "version": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "version": "2.0.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "p-locate": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-            "path-exists": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz"
+            "p-locate": "2.0.0",
+            "path-exists": "3.0.0"
           },
           "dependencies": {
             "path-exists": {
-              "version": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-              "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+              "version": "3.0.0",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "lodash": {
-          "version": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "version": "4.17.4",
+          "bundled": true,
           "dev": true
         },
         "longest": {
-          "version": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-          "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+          "version": "1.0.1",
+          "bundled": true,
           "dev": true
         },
         "loose-envify": {
-          "version": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-          "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+          "version": "1.3.1",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "js-tokens": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
+            "js-tokens": "3.0.1"
           }
         },
         "lru-cache": {
-          "version": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-          "integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
+          "version": "4.1.1",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "pseudomap": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-            "yallist": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz"
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
           }
         },
         "md5-hex": {
-          "version": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
-          "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
+          "version": "1.3.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "md5-o-matic": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz"
+            "md5-o-matic": "0.1.1"
           }
         },
         "md5-o-matic": {
-          "version": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
-          "integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
+          "version": "0.1.1",
+          "bundled": true,
           "dev": true
         },
         "mem": {
-          "version": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-          "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+          "version": "1.1.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "mimic-fn": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz"
+            "mimic-fn": "1.1.0"
           }
         },
         "merge-source-map": {
-          "version": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.0.4.tgz",
-          "integrity": "sha1-pd5GU42uhNQRTMXqArR3KmNGcB8=",
+          "version": "1.0.4",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+            "source-map": "0.5.6"
           }
         },
         "micromatch": {
-          "version": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+          "version": "2.3.11",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "arr-diff": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-            "array-unique": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-            "braces": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-            "expand-brackets": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-            "extglob": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-            "filename-regex": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-            "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-            "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-            "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-            "normalize-path": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-            "object.omit": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-            "parse-glob": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-            "regex-cache": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz"
+            "arr-diff": "2.0.0",
+            "array-unique": "0.2.1",
+            "braces": "1.8.5",
+            "expand-brackets": "0.1.5",
+            "extglob": "0.3.2",
+            "filename-regex": "2.0.1",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1",
+            "kind-of": "3.2.2",
+            "normalize-path": "2.1.1",
+            "object.omit": "2.0.1",
+            "parse-glob": "3.0.4",
+            "regex-cache": "0.4.3"
           }
         },
         "mimic-fn": {
-          "version": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
-          "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
+          "version": "1.1.0",
+          "bundled": true,
           "dev": true
         },
         "minimatch": {
-          "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+          "version": "3.0.4",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz"
+            "brace-expansion": "1.1.8"
           }
         },
         "minimist": {
-          "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "version": "0.0.8",
+          "bundled": true,
           "dev": true
         },
         "mkdirp": {
-          "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "version": "0.5.1",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            "minimist": "0.0.8"
           }
         },
         "ms": {
-          "version": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "version": "2.0.0",
+          "bundled": true,
           "dev": true
         },
         "normalize-package-data": {
-          "version": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
-          "integrity": "sha1-2Bntoqne29H/pWPqQHHZNngilbs=",
+          "version": "2.3.8",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "hosted-git-info": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.2.tgz",
-            "is-builtin-module": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-            "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-            "validate-npm-package-license": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
+            "hosted-git-info": "2.4.2",
+            "is-builtin-module": "1.0.0",
+            "semver": "5.3.0",
+            "validate-npm-package-license": "3.0.1"
           }
         },
         "normalize-path": {
-          "version": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+          "version": "2.1.1",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "remove-trailing-separator": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz"
+            "remove-trailing-separator": "1.0.2"
           }
         },
         "npm-run-path": {
-          "version": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+          "version": "2.0.2",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "path-key": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz"
+            "path-key": "2.0.1"
           }
         },
         "number-is-nan": {
-          "version": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "version": "1.0.1",
+          "bundled": true,
           "dev": true
         },
         "object-assign": {
-          "version": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "version": "4.1.1",
+          "bundled": true,
           "dev": true
         },
         "object.omit": {
-          "version": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-          "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+          "version": "2.0.1",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "for-own": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-            "is-extendable": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
+            "for-own": "0.1.5",
+            "is-extendable": "0.1.1"
           }
         },
         "once": {
-          "version": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "version": "1.4.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+            "wrappy": "1.0.2"
           }
         },
         "optimist": {
-          "version": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-          "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+          "version": "0.6.1",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-            "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+            "minimist": "0.0.8",
+            "wordwrap": "0.0.3"
           }
         },
         "os-homedir": {
-          "version": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+          "version": "1.0.2",
+          "bundled": true,
           "dev": true
         },
         "os-locale": {
-          "version": "https://registry.npmjs.org/os-locale/-/os-locale-2.0.0.tgz",
-          "integrity": "sha1-FZGN7VEFIrge565aMJ1U9jn8OaQ=",
+          "version": "2.0.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "execa": "https://registry.npmjs.org/execa/-/execa-0.5.1.tgz",
-            "lcid": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-            "mem": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz"
+            "execa": "0.5.1",
+            "lcid": "1.0.0",
+            "mem": "1.1.0"
           }
         },
         "p-finally": {
-          "version": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+          "version": "1.0.0",
+          "bundled": true,
           "dev": true
         },
         "p-limit": {
-          "version": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
-          "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
+          "version": "1.1.0",
+          "bundled": true,
           "dev": true
         },
         "p-locate": {
-          "version": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "version": "2.0.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "p-limit": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz"
+            "p-limit": "1.1.0"
           }
         },
         "parse-glob": {
-          "version": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-          "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+          "version": "3.0.4",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "glob-base": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-            "is-dotfile": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-            "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-            "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
+            "glob-base": "0.3.0",
+            "is-dotfile": "1.0.3",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1"
           }
         },
         "parse-json": {
-          "version": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "version": "2.2.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "error-ex": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz"
+            "error-ex": "1.3.1"
           }
         },
         "path-exists": {
-          "version": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "version": "2.1.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+            "pinkie-promise": "2.0.1"
           }
         },
         "path-is-absolute": {
-          "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+          "version": "1.0.1",
+          "bundled": true,
           "dev": true
         },
         "path-key": {
-          "version": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+          "version": "2.0.1",
+          "bundled": true,
           "dev": true
         },
         "path-parse": {
-          "version": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-          "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+          "version": "1.0.5",
+          "bundled": true,
           "dev": true
         },
         "path-type": {
-          "version": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "version": "1.1.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-            "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-            "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+            "graceful-fs": "4.1.11",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "pify": {
-          "version": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "version": "2.3.0",
+          "bundled": true,
           "dev": true
         },
         "pinkie": {
-          "version": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+          "version": "2.0.4",
+          "bundled": true,
           "dev": true
         },
         "pinkie-promise": {
-          "version": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+          "version": "2.0.1",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "pinkie": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+            "pinkie": "2.0.4"
           }
         },
         "pkg-dir": {
-          "version": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
-          "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+          "version": "1.0.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "find-up": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz"
+            "find-up": "1.1.2"
           },
           "dependencies": {
             "find-up": {
-              "version": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-              "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+              "version": "1.1.2",
+              "bundled": true,
               "dev": true,
               "requires": {
-                "path-exists": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-                "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+                "path-exists": "2.1.0",
+                "pinkie-promise": "2.0.1"
               }
             }
           }
         },
         "preserve": {
-          "version": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-          "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+          "version": "0.2.0",
+          "bundled": true,
           "dev": true
         },
         "pseudomap": {
-          "version": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-          "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+          "version": "1.0.2",
+          "bundled": true,
           "dev": true
         },
         "randomatic": {
-          "version": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-          "integrity": "sha1-x6vpzIuHwLqodrGf3oP9RkeX44w=",
+          "version": "1.1.7",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "is-number": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-            "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz"
+            "is-number": "3.0.0",
+            "kind-of": "4.0.0"
           },
           "dependencies": {
             "is-number": {
-              "version": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-              "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+              "version": "3.0.0",
+              "bundled": true,
               "dev": true,
               "requires": {
-                "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
-                  "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "version": "3.2.2",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
-                    "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+                    "is-buffer": "1.1.5"
                   }
                 }
               }
             },
             "kind-of": {
-              "version": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-              "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+              "version": "4.0.0",
+              "bundled": true,
               "dev": true,
               "requires": {
-                "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+                "is-buffer": "1.1.5"
               }
             }
           }
         },
         "read-pkg": {
-          "version": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+          "version": "1.1.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "load-json-file": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-            "normalize-package-data": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
-            "path-type": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz"
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.3.8",
+            "path-type": "1.1.0"
           }
         },
         "read-pkg-up": {
-          "version": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+          "version": "1.0.1",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "find-up": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-            "read-pkg": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz"
+            "find-up": "1.1.2",
+            "read-pkg": "1.1.0"
           },
           "dependencies": {
             "find-up": {
-              "version": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-              "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+              "version": "1.1.2",
+              "bundled": true,
               "dev": true,
               "requires": {
-                "path-exists": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-                "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+                "path-exists": "2.1.0",
+                "pinkie-promise": "2.0.1"
               }
             }
           }
         },
         "regenerator-runtime": {
-          "version": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+          "version": "0.10.5",
+          "bundled": true,
           "dev": true
         },
         "regex-cache": {
-          "version": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
-          "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
+          "version": "0.4.3",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "is-equal-shallow": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-            "is-primitive": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
+            "is-equal-shallow": "0.1.3",
+            "is-primitive": "2.0.0"
           }
         },
         "remove-trailing-separator": {
-          "version": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz",
-          "integrity": "sha1-abBi2XhyetFNxrVrpKt3L9jXBRE=",
+          "version": "1.0.2",
+          "bundled": true,
           "dev": true
         },
         "repeat-element": {
-          "version": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-          "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+          "version": "1.1.2",
+          "bundled": true,
           "dev": true
         },
         "repeat-string": {
-          "version": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-          "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+          "version": "1.6.1",
+          "bundled": true,
           "dev": true
         },
         "repeating": {
-          "version": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-          "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+          "version": "2.0.1",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "is-finite": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz"
+            "is-finite": "1.0.2"
           }
         },
         "require-directory": {
-          "version": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-          "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+          "version": "2.1.1",
+          "bundled": true,
           "dev": true
         },
         "require-main-filename": {
-          "version": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+          "version": "1.0.1",
+          "bundled": true,
           "dev": true
         },
         "resolve-from": {
-          "version": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-          "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
+          "version": "2.0.0",
+          "bundled": true,
           "dev": true
         },
         "right-align": {
-          "version": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-          "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+          "version": "0.1.3",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "align-text": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz"
+            "align-text": "0.1.4"
           }
         },
         "rimraf": {
-          "version": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-          "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+          "version": "2.6.1",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "glob": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz"
+            "glob": "7.1.2"
           }
         },
         "semver": {
-          "version": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+          "version": "5.3.0",
+          "bundled": true,
           "dev": true
         },
         "set-blocking": {
-          "version": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+          "version": "2.0.0",
+          "bundled": true,
           "dev": true
         },
         "signal-exit": {
-          "version": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+          "version": "3.0.2",
+          "bundled": true,
           "dev": true
         },
         "slide": {
-          "version": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-          "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
+          "version": "1.1.6",
+          "bundled": true,
           "dev": true
         },
         "source-map": {
-          "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+          "version": "0.5.6",
+          "bundled": true,
           "dev": true
         },
         "spawn-wrap": {
-          "version": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.3.7.tgz",
-          "integrity": "sha1-vri/RCbWSysGhx4Nfe4mQ/H40bw=",
+          "version": "1.3.7",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "foreground-child": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
-            "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-            "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-            "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-            "signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-            "which": "https://registry.npmjs.org/which/-/which-1.2.14.tgz"
+            "foreground-child": "1.5.6",
+            "mkdirp": "0.5.1",
+            "os-homedir": "1.0.2",
+            "rimraf": "2.6.1",
+            "signal-exit": "3.0.2",
+            "which": "1.2.14"
           }
         },
         "spdx-correct": {
-          "version": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-          "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+          "version": "1.0.2",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "spdx-license-ids": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz"
+            "spdx-license-ids": "1.2.2"
           }
         },
         "spdx-expression-parse": {
-          "version": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-          "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
+          "version": "1.0.4",
+          "bundled": true,
           "dev": true
         },
         "spdx-license-ids": {
-          "version": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-          "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+          "version": "1.2.2",
+          "bundled": true,
           "dev": true
         },
         "string-width": {
-          "version": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
-          "integrity": "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4=",
+          "version": "2.0.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "3.0.1"
           },
           "dependencies": {
             "is-fullwidth-code-point": {
-              "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+              "version": "2.0.0",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "strip-ansi": {
-          "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "version": "3.0.1",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+            "ansi-regex": "2.1.1"
           }
         },
         "strip-bom": {
-          "version": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "version": "2.0.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "is-utf8": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
+            "is-utf8": "0.2.1"
           }
         },
         "strip-eof": {
-          "version": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-          "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+          "version": "1.0.0",
+          "bundled": true,
           "dev": true
         },
         "supports-color": {
-          "version": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "version": "2.0.0",
+          "bundled": true,
           "dev": true
         },
         "test-exclude": {
-          "version": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.1.1.tgz",
-          "integrity": "sha1-TYSWSwlmsAh+zDNKLOAC09k0HiY=",
+          "version": "4.1.1",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "arrify": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-            "micromatch": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-            "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-            "read-pkg-up": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-            "require-main-filename": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz"
+            "arrify": "1.0.1",
+            "micromatch": "2.3.11",
+            "object-assign": "4.1.1",
+            "read-pkg-up": "1.0.1",
+            "require-main-filename": "1.0.1"
           }
         },
         "to-fast-properties": {
-          "version": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-          "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+          "version": "1.0.3",
+          "bundled": true,
           "dev": true
         },
         "trim-right": {
-          "version": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-          "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+          "version": "1.0.1",
+          "bundled": true,
           "dev": true
         },
         "uglify-js": {
-          "version": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+          "version": "2.8.29",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-            "uglify-to-browserify": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-            "yargs": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz"
+            "source-map": "0.5.6",
+            "uglify-to-browserify": "1.0.2",
+            "yargs": "3.10.0"
           },
           "dependencies": {
             "yargs": {
-              "version": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-              "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+              "version": "3.10.0",
+              "bundled": true,
               "dev": true,
               "optional": true,
               "requires": {
-                "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-                "cliui": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-                "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-                "window-size": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+                "camelcase": "1.2.1",
+                "cliui": "2.1.0",
+                "decamelize": "1.2.0",
+                "window-size": "0.1.0"
               }
             }
           }
         },
         "uglify-to-browserify": {
-          "version": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-          "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+          "version": "1.0.2",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "validate-npm-package-license": {
-          "version": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-          "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+          "version": "3.0.1",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "spdx-correct": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-            "spdx-expression-parse": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz"
+            "spdx-correct": "1.0.2",
+            "spdx-expression-parse": "1.0.4"
           }
         },
         "which": {
-          "version": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-          "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
+          "version": "1.2.14",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "isexe": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
+            "isexe": "2.0.0"
           }
         },
         "which-module": {
-          "version": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+          "version": "2.0.0",
+          "bundled": true,
           "dev": true
         },
         "window-size": {
-          "version": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-          "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+          "version": "0.1.0",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "wordwrap": {
-          "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+          "version": "0.0.3",
+          "bundled": true,
           "dev": true
         },
         "wrap-ansi": {
-          "version": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+          "version": "2.1.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1"
           },
           "dependencies": {
             "string-width": {
-              "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "version": "1.0.2",
+              "bundled": true,
               "dev": true,
               "requires": {
-                "code-point-at": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-                "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
               }
             }
           }
         },
         "wrappy": {
-          "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+          "version": "1.0.2",
+          "bundled": true,
           "dev": true
         },
         "write-file-atomic": {
-          "version": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
-          "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
+          "version": "1.3.4",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-            "imurmurhash": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-            "slide": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
+            "graceful-fs": "4.1.11",
+            "imurmurhash": "0.1.4",
+            "slide": "1.1.6"
           }
         },
         "y18n": {
-          "version": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+          "version": "3.2.1",
+          "bundled": true,
           "dev": true
         },
         "yallist": {
-          "version": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+          "version": "2.1.2",
+          "bundled": true,
           "dev": true
         },
         "yargs": {
-          "version": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
-          "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
+          "version": "8.0.2",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-            "cliui": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-            "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-            "get-caller-file": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-            "os-locale": "https://registry.npmjs.org/os-locale/-/os-locale-2.0.0.tgz",
-            "read-pkg-up": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-            "require-directory": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-            "require-main-filename": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-            "set-blocking": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-            "string-width": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
-            "which-module": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-            "y18n": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-            "yargs-parser": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz"
+            "camelcase": "4.1.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "2.0.0",
+            "read-pkg-up": "2.0.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.0.0",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "7.0.0"
           },
           "dependencies": {
             "camelcase": {
-              "version": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-              "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+              "version": "4.1.0",
+              "bundled": true,
               "dev": true
             },
             "cliui": {
-              "version": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-              "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+              "version": "3.2.0",
+              "bundled": true,
               "dev": true,
               "requires": {
-                "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                "wrap-ansi": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz"
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1",
+                "wrap-ansi": "2.1.0"
               },
               "dependencies": {
                 "string-width": {
-                  "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                  "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                  "version": "1.0.2",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
-                    "code-point-at": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-                    "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                    "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+                    "code-point-at": "1.1.0",
+                    "is-fullwidth-code-point": "1.0.0",
+                    "strip-ansi": "3.0.1"
                   }
                 }
               }
             },
             "load-json-file": {
-              "version": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-              "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+              "version": "2.0.0",
+              "bundled": true,
               "dev": true,
               "requires": {
-                "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-                "parse-json": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-                "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz"
+                "graceful-fs": "4.1.11",
+                "parse-json": "2.2.0",
+                "pify": "2.3.0",
+                "strip-bom": "3.0.0"
               }
             },
             "path-type": {
-              "version": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-              "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+              "version": "2.0.0",
+              "bundled": true,
               "dev": true,
               "requires": {
-                "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+                "pify": "2.3.0"
               }
             },
             "read-pkg": {
-              "version": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-              "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+              "version": "2.0.0",
+              "bundled": true,
               "dev": true,
               "requires": {
-                "load-json-file": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-                "normalize-package-data": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
-                "path-type": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz"
+                "load-json-file": "2.0.0",
+                "normalize-package-data": "2.3.8",
+                "path-type": "2.0.0"
               }
             },
             "read-pkg-up": {
-              "version": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-              "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+              "version": "2.0.0",
+              "bundled": true,
               "dev": true,
               "requires": {
-                "find-up": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-                "read-pkg": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz"
+                "find-up": "2.1.0",
+                "read-pkg": "2.0.0"
               }
             },
             "strip-bom": {
-              "version": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-              "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+              "version": "3.0.0",
+              "bundled": true,
               "dev": true
             },
             "yargs-parser": {
-              "version": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
-              "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+              "version": "7.0.0",
+              "bundled": true,
               "dev": true,
               "requires": {
-                "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz"
+                "camelcase": "4.1.0"
               }
             }
           }
         },
         "yargs-parser": {
-          "version": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
-          "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+          "version": "5.0.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz"
+            "camelcase": "3.0.0"
           },
           "dependencies": {
             "camelcase": {
-              "version": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-              "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+              "version": "3.0.0",
+              "bundled": true,
               "dev": true
             }
           }
@@ -2006,9 +2054,9 @@
       "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
     },
     "sinon": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-2.3.6.tgz",
-      "integrity": "sha1-lTeOfg+XapcS6bRZH/WznnPcPd4=",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-2.3.8.tgz",
+      "integrity": "sha1-Md4G/tj7o6Zx5XbdltClhjeW8lw=",
       "dev": true,
       "requires": {
         "diff": "3.2.0",
@@ -2036,1704 +2084,12 @@
       }
     },
     "swatchjs": {
-      "version": "0.1.0",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/swatchjs/-/swatchjs-0.1.2.tgz",
+      "integrity": "sha512-6Ho7RQqHHQbfR5ETylfCtsOaWnJfSa6ga4k27ENKu2Y11anA/A+XhSgkJVz1Y56JDie0f6H8WblBkg7xSbVIdQ==",
       "requires": {
         "function-arguments": "1.0.8",
-        "joi": "10.6.0",
-        "to-camel-case": "1.0.0"
-      },
-      "dependencies": {
-        "assertion-error": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "brace-expansion": {
-          "version": "1.1.8",
-          "bundled": true,
-          "requires": {
-            "balanced-match": "1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "browser-stdout": {
-          "version": "1.3.0",
-          "bundled": true
-        },
-        "chai": {
-          "version": "4.0.2",
-          "bundled": true,
-          "requires": {
-            "assertion-error": "1.0.2",
-            "check-error": "1.0.2",
-            "deep-eql": "2.0.2",
-            "get-func-name": "2.0.0",
-            "pathval": "1.1.0",
-            "type-detect": "4.0.3"
-          }
-        },
-        "check-error": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "commander": {
-          "version": "2.9.0",
-          "bundled": true,
-          "requires": {
-            "graceful-readlink": "1.0.1"
-          }
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true
-        },
-        "debug": {
-          "version": "2.6.0",
-          "bundled": true,
-          "requires": {
-            "ms": "0.7.2"
-          }
-        },
-        "deep-eql": {
-          "version": "2.0.2",
-          "bundled": true,
-          "requires": {
-            "type-detect": "3.0.0"
-          },
-          "dependencies": {
-            "type-detect": {
-              "version": "3.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "diff": {
-          "version": "3.2.0",
-          "bundled": true
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "bundled": true
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "function-arguments": {
-          "version": "1.0.8",
-          "bundled": true
-        },
-        "get-func-name": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "glob": {
-          "version": "7.1.1",
-          "bundled": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "graceful-readlink": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "growl": {
-          "version": "1.9.2",
-          "bundled": true
-        },
-        "has-flag": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "hoek": {
-          "version": "4.1.1",
-          "bundled": true
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true
-        },
-        "isemail": {
-          "version": "2.2.1",
-          "bundled": true
-        },
-        "items": {
-          "version": "2.1.1",
-          "bundled": true
-        },
-        "joi": {
-          "version": "10.6.0",
-          "bundled": true,
-          "requires": {
-            "hoek": "4.1.1",
-            "isemail": "2.2.1",
-            "items": "2.1.1",
-            "topo": "2.0.2"
-          }
-        },
-        "json3": {
-          "version": "3.3.2",
-          "bundled": true
-        },
-        "lodash._baseassign": {
-          "version": "3.2.0",
-          "bundled": true,
-          "requires": {
-            "lodash._basecopy": "3.0.1",
-            "lodash.keys": "3.1.2"
-          }
-        },
-        "lodash._basecopy": {
-          "version": "3.0.1",
-          "bundled": true
-        },
-        "lodash._basecreate": {
-          "version": "3.0.3",
-          "bundled": true
-        },
-        "lodash._getnative": {
-          "version": "3.9.1",
-          "bundled": true
-        },
-        "lodash._isiterateecall": {
-          "version": "3.0.9",
-          "bundled": true
-        },
-        "lodash.create": {
-          "version": "3.1.1",
-          "bundled": true,
-          "requires": {
-            "lodash._baseassign": "3.2.0",
-            "lodash._basecreate": "3.0.3",
-            "lodash._isiterateecall": "3.0.9"
-          }
-        },
-        "lodash.isarguments": {
-          "version": "3.1.0",
-          "bundled": true
-        },
-        "lodash.isarray": {
-          "version": "3.0.4",
-          "bundled": true
-        },
-        "lodash.keys": {
-          "version": "3.1.2",
-          "bundled": true,
-          "requires": {
-            "lodash._getnative": "3.9.1",
-            "lodash.isarguments": "3.1.0",
-            "lodash.isarray": "3.0.4"
-          }
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "bundled": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "mocha": {
-          "version": "3.4.2",
-          "bundled": true,
-          "requires": {
-            "browser-stdout": "1.3.0",
-            "commander": "2.9.0",
-            "debug": "2.6.0",
-            "diff": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "glob": "7.1.1",
-            "growl": "1.9.2",
-            "json3": "3.3.2",
-            "lodash.create": "3.1.1",
-            "mkdirp": "0.5.1",
-            "supports-color": "3.1.2"
-          }
-        },
-        "ms": {
-          "version": "0.7.2",
-          "bundled": true
-        },
-        "nyc": {
-          "version": "11.0.3",
-          "bundled": true,
-          "requires": {
-            "archy": "1.0.0",
-            "arrify": "1.0.1",
-            "caching-transform": "1.0.1",
-            "convert-source-map": "1.5.0",
-            "debug-log": "1.0.1",
-            "default-require-extensions": "1.0.0",
-            "find-cache-dir": "0.1.1",
-            "find-up": "2.1.0",
-            "foreground-child": "1.5.6",
-            "glob": "7.1.2",
-            "istanbul-lib-coverage": "1.1.1",
-            "istanbul-lib-hook": "1.0.7",
-            "istanbul-lib-instrument": "1.7.3",
-            "istanbul-lib-report": "1.1.1",
-            "istanbul-lib-source-maps": "1.2.1",
-            "istanbul-reports": "1.1.1",
-            "md5-hex": "1.3.0",
-            "merge-source-map": "1.0.4",
-            "micromatch": "2.3.11",
-            "mkdirp": "0.5.1",
-            "resolve-from": "2.0.0",
-            "rimraf": "2.6.1",
-            "signal-exit": "3.0.2",
-            "spawn-wrap": "1.3.7",
-            "test-exclude": "4.1.1",
-            "yargs": "8.0.2",
-            "yargs-parser": "5.0.0"
-          },
-          "dependencies": {
-            "align-text": {
-              "version": "0.1.4",
-              "bundled": true,
-              "requires": {
-                "kind-of": "3.2.2",
-                "longest": "1.0.1",
-                "repeat-string": "1.6.1"
-              }
-            },
-            "amdefine": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "ansi-regex": {
-              "version": "2.1.1",
-              "bundled": true
-            },
-            "ansi-styles": {
-              "version": "2.2.1",
-              "bundled": true
-            },
-            "append-transform": {
-              "version": "0.4.0",
-              "bundled": true,
-              "requires": {
-                "default-require-extensions": "1.0.0"
-              }
-            },
-            "archy": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "arr-diff": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "arr-flatten": "1.0.3"
-              }
-            },
-            "arr-flatten": {
-              "version": "1.0.3",
-              "bundled": true
-            },
-            "array-unique": {
-              "version": "0.2.1",
-              "bundled": true
-            },
-            "arrify": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "async": {
-              "version": "1.5.2",
-              "bundled": true
-            },
-            "babel-code-frame": {
-              "version": "6.22.0",
-              "bundled": true,
-              "requires": {
-                "chalk": "1.1.3",
-                "esutils": "2.0.2",
-                "js-tokens": "3.0.1"
-              }
-            },
-            "babel-generator": {
-              "version": "6.25.0",
-              "bundled": true,
-              "requires": {
-                "babel-messages": "6.23.0",
-                "babel-runtime": "6.23.0",
-                "babel-types": "6.25.0",
-                "detect-indent": "4.0.0",
-                "jsesc": "1.3.0",
-                "lodash": "4.17.4",
-                "source-map": "0.5.6",
-                "trim-right": "1.0.1"
-              }
-            },
-            "babel-messages": {
-              "version": "6.23.0",
-              "bundled": true,
-              "requires": {
-                "babel-runtime": "6.23.0"
-              }
-            },
-            "babel-runtime": {
-              "version": "6.23.0",
-              "bundled": true,
-              "requires": {
-                "core-js": "2.4.1",
-                "regenerator-runtime": "0.10.5"
-              }
-            },
-            "babel-template": {
-              "version": "6.25.0",
-              "bundled": true,
-              "requires": {
-                "babel-runtime": "6.23.0",
-                "babel-traverse": "6.25.0",
-                "babel-types": "6.25.0",
-                "babylon": "6.17.4",
-                "lodash": "4.17.4"
-              }
-            },
-            "babel-traverse": {
-              "version": "6.25.0",
-              "bundled": true,
-              "requires": {
-                "babel-code-frame": "6.22.0",
-                "babel-messages": "6.23.0",
-                "babel-runtime": "6.23.0",
-                "babel-types": "6.25.0",
-                "babylon": "6.17.4",
-                "debug": "2.6.8",
-                "globals": "9.18.0",
-                "invariant": "2.2.2",
-                "lodash": "4.17.4"
-              }
-            },
-            "babel-types": {
-              "version": "6.25.0",
-              "bundled": true,
-              "requires": {
-                "babel-runtime": "6.23.0",
-                "esutils": "2.0.2",
-                "lodash": "4.17.4",
-                "to-fast-properties": "1.0.3"
-              }
-            },
-            "babylon": {
-              "version": "6.17.4",
-              "bundled": true
-            },
-            "balanced-match": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "brace-expansion": {
-              "version": "1.1.8",
-              "bundled": true,
-              "requires": {
-                "balanced-match": "1.0.0",
-                "concat-map": "0.0.1"
-              }
-            },
-            "braces": {
-              "version": "1.8.5",
-              "bundled": true,
-              "requires": {
-                "expand-range": "1.8.2",
-                "preserve": "0.2.0",
-                "repeat-element": "1.1.2"
-              }
-            },
-            "builtin-modules": {
-              "version": "1.1.1",
-              "bundled": true
-            },
-            "caching-transform": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "md5-hex": "1.3.0",
-                "mkdirp": "0.5.1",
-                "write-file-atomic": "1.3.4"
-              }
-            },
-            "camelcase": {
-              "version": "1.2.1",
-              "bundled": true,
-              "optional": true
-            },
-            "center-align": {
-              "version": "0.1.3",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "align-text": "0.1.4",
-                "lazy-cache": "1.0.4"
-              }
-            },
-            "chalk": {
-              "version": "1.1.3",
-              "bundled": true,
-              "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
-              }
-            },
-            "cliui": {
-              "version": "2.1.0",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "center-align": "0.1.3",
-                "right-align": "0.1.3",
-                "wordwrap": "0.0.2"
-              },
-              "dependencies": {
-                "wordwrap": {
-                  "version": "0.0.2",
-                  "bundled": true,
-                  "optional": true
-                }
-              }
-            },
-            "code-point-at": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "commondir": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "concat-map": {
-              "version": "0.0.1",
-              "bundled": true
-            },
-            "convert-source-map": {
-              "version": "1.5.0",
-              "bundled": true
-            },
-            "core-js": {
-              "version": "2.4.1",
-              "bundled": true
-            },
-            "cross-spawn": {
-              "version": "4.0.2",
-              "bundled": true,
-              "requires": {
-                "lru-cache": "4.1.1",
-                "which": "1.2.14"
-              }
-            },
-            "debug": {
-              "version": "2.6.8",
-              "bundled": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "debug-log": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "decamelize": {
-              "version": "1.2.0",
-              "bundled": true
-            },
-            "default-require-extensions": {
-              "version": "1.0.0",
-              "bundled": true,
-              "requires": {
-                "strip-bom": "2.0.0"
-              }
-            },
-            "detect-indent": {
-              "version": "4.0.0",
-              "bundled": true,
-              "requires": {
-                "repeating": "2.0.1"
-              }
-            },
-            "error-ex": {
-              "version": "1.3.1",
-              "bundled": true,
-              "requires": {
-                "is-arrayish": "0.2.1"
-              }
-            },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "bundled": true
-            },
-            "esutils": {
-              "version": "2.0.2",
-              "bundled": true
-            },
-            "execa": {
-              "version": "0.5.1",
-              "bundled": true,
-              "requires": {
-                "cross-spawn": "4.0.2",
-                "get-stream": "2.3.1",
-                "is-stream": "1.1.0",
-                "npm-run-path": "2.0.2",
-                "p-finally": "1.0.0",
-                "signal-exit": "3.0.2",
-                "strip-eof": "1.0.0"
-              }
-            },
-            "expand-brackets": {
-              "version": "0.1.5",
-              "bundled": true,
-              "requires": {
-                "is-posix-bracket": "0.1.1"
-              }
-            },
-            "expand-range": {
-              "version": "1.8.2",
-              "bundled": true,
-              "requires": {
-                "fill-range": "2.2.3"
-              }
-            },
-            "extglob": {
-              "version": "0.3.2",
-              "bundled": true,
-              "requires": {
-                "is-extglob": "1.0.0"
-              }
-            },
-            "filename-regex": {
-              "version": "2.0.1",
-              "bundled": true
-            },
-            "fill-range": {
-              "version": "2.2.3",
-              "bundled": true,
-              "requires": {
-                "is-number": "2.1.0",
-                "isobject": "2.1.0",
-                "randomatic": "1.1.7",
-                "repeat-element": "1.1.2",
-                "repeat-string": "1.6.1"
-              }
-            },
-            "find-cache-dir": {
-              "version": "0.1.1",
-              "bundled": true,
-              "requires": {
-                "commondir": "1.0.1",
-                "mkdirp": "0.5.1",
-                "pkg-dir": "1.0.0"
-              }
-            },
-            "find-up": {
-              "version": "2.1.0",
-              "bundled": true,
-              "requires": {
-                "locate-path": "2.0.0"
-              }
-            },
-            "for-in": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "for-own": {
-              "version": "0.1.5",
-              "bundled": true,
-              "requires": {
-                "for-in": "1.0.2"
-              }
-            },
-            "foreground-child": {
-              "version": "1.5.6",
-              "bundled": true,
-              "requires": {
-                "cross-spawn": "4.0.2",
-                "signal-exit": "3.0.2"
-              }
-            },
-            "fs.realpath": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "get-caller-file": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "get-stream": {
-              "version": "2.3.1",
-              "bundled": true,
-              "requires": {
-                "object-assign": "4.1.1",
-                "pinkie-promise": "2.0.1"
-              }
-            },
-            "glob": {
-              "version": "7.1.2",
-              "bundled": true,
-              "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
-              }
-            },
-            "glob-base": {
-              "version": "0.3.0",
-              "bundled": true,
-              "requires": {
-                "glob-parent": "2.0.0",
-                "is-glob": "2.0.1"
-              }
-            },
-            "glob-parent": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "is-glob": "2.0.1"
-              }
-            },
-            "globals": {
-              "version": "9.18.0",
-              "bundled": true
-            },
-            "graceful-fs": {
-              "version": "4.1.11",
-              "bundled": true
-            },
-            "handlebars": {
-              "version": "4.0.10",
-              "bundled": true,
-              "requires": {
-                "async": "1.5.2",
-                "optimist": "0.6.1",
-                "source-map": "0.4.4",
-                "uglify-js": "2.8.29"
-              },
-              "dependencies": {
-                "source-map": {
-                  "version": "0.4.4",
-                  "bundled": true,
-                  "requires": {
-                    "amdefine": "1.0.1"
-                  }
-                }
-              }
-            },
-            "has-ansi": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "ansi-regex": "2.1.1"
-              }
-            },
-            "has-flag": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "hosted-git-info": {
-              "version": "2.4.2",
-              "bundled": true
-            },
-            "imurmurhash": {
-              "version": "0.1.4",
-              "bundled": true
-            },
-            "inflight": {
-              "version": "1.0.6",
-              "bundled": true,
-              "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
-              }
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "bundled": true
-            },
-            "invariant": {
-              "version": "2.2.2",
-              "bundled": true,
-              "requires": {
-                "loose-envify": "1.3.1"
-              }
-            },
-            "invert-kv": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "is-arrayish": {
-              "version": "0.2.1",
-              "bundled": true
-            },
-            "is-buffer": {
-              "version": "1.1.5",
-              "bundled": true
-            },
-            "is-builtin-module": {
-              "version": "1.0.0",
-              "bundled": true,
-              "requires": {
-                "builtin-modules": "1.1.1"
-              }
-            },
-            "is-dotfile": {
-              "version": "1.0.3",
-              "bundled": true
-            },
-            "is-equal-shallow": {
-              "version": "0.1.3",
-              "bundled": true,
-              "requires": {
-                "is-primitive": "2.0.0"
-              }
-            },
-            "is-extendable": {
-              "version": "0.1.1",
-              "bundled": true
-            },
-            "is-extglob": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "is-finite": {
-              "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "number-is-nan": "1.0.1"
-              }
-            },
-            "is-fullwidth-code-point": {
-              "version": "1.0.0",
-              "bundled": true,
-              "requires": {
-                "number-is-nan": "1.0.1"
-              }
-            },
-            "is-glob": {
-              "version": "2.0.1",
-              "bundled": true,
-              "requires": {
-                "is-extglob": "1.0.0"
-              }
-            },
-            "is-number": {
-              "version": "2.1.0",
-              "bundled": true,
-              "requires": {
-                "kind-of": "3.2.2"
-              }
-            },
-            "is-posix-bracket": {
-              "version": "0.1.1",
-              "bundled": true
-            },
-            "is-primitive": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "is-stream": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "is-utf8": {
-              "version": "0.2.1",
-              "bundled": true
-            },
-            "isarray": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "isexe": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "isobject": {
-              "version": "2.1.0",
-              "bundled": true,
-              "requires": {
-                "isarray": "1.0.0"
-              }
-            },
-            "istanbul-lib-coverage": {
-              "version": "1.1.1",
-              "bundled": true
-            },
-            "istanbul-lib-hook": {
-              "version": "1.0.7",
-              "bundled": true,
-              "requires": {
-                "append-transform": "0.4.0"
-              }
-            },
-            "istanbul-lib-instrument": {
-              "version": "1.7.3",
-              "bundled": true,
-              "requires": {
-                "babel-generator": "6.25.0",
-                "babel-template": "6.25.0",
-                "babel-traverse": "6.25.0",
-                "babel-types": "6.25.0",
-                "babylon": "6.17.4",
-                "istanbul-lib-coverage": "1.1.1",
-                "semver": "5.3.0"
-              }
-            },
-            "istanbul-lib-report": {
-              "version": "1.1.1",
-              "bundled": true,
-              "requires": {
-                "istanbul-lib-coverage": "1.1.1",
-                "mkdirp": "0.5.1",
-                "path-parse": "1.0.5",
-                "supports-color": "3.2.3"
-              },
-              "dependencies": {
-                "supports-color": {
-                  "version": "3.2.3",
-                  "bundled": true,
-                  "requires": {
-                    "has-flag": "1.0.0"
-                  }
-                }
-              }
-            },
-            "istanbul-lib-source-maps": {
-              "version": "1.2.1",
-              "bundled": true,
-              "requires": {
-                "debug": "2.6.8",
-                "istanbul-lib-coverage": "1.1.1",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.1",
-                "source-map": "0.5.6"
-              }
-            },
-            "istanbul-reports": {
-              "version": "1.1.1",
-              "bundled": true,
-              "requires": {
-                "handlebars": "4.0.10"
-              }
-            },
-            "js-tokens": {
-              "version": "3.0.1",
-              "bundled": true
-            },
-            "jsesc": {
-              "version": "1.3.0",
-              "bundled": true
-            },
-            "kind-of": {
-              "version": "3.2.2",
-              "bundled": true,
-              "requires": {
-                "is-buffer": "1.1.5"
-              }
-            },
-            "lazy-cache": {
-              "version": "1.0.4",
-              "bundled": true,
-              "optional": true
-            },
-            "lcid": {
-              "version": "1.0.0",
-              "bundled": true,
-              "requires": {
-                "invert-kv": "1.0.0"
-              }
-            },
-            "load-json-file": {
-              "version": "1.1.0",
-              "bundled": true,
-              "requires": {
-                "graceful-fs": "4.1.11",
-                "parse-json": "2.2.0",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1",
-                "strip-bom": "2.0.0"
-              }
-            },
-            "locate-path": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "p-locate": "2.0.0",
-                "path-exists": "3.0.0"
-              },
-              "dependencies": {
-                "path-exists": {
-                  "version": "3.0.0",
-                  "bundled": true
-                }
-              }
-            },
-            "lodash": {
-              "version": "4.17.4",
-              "bundled": true
-            },
-            "longest": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "loose-envify": {
-              "version": "1.3.1",
-              "bundled": true,
-              "requires": {
-                "js-tokens": "3.0.1"
-              }
-            },
-            "lru-cache": {
-              "version": "4.1.1",
-              "bundled": true,
-              "requires": {
-                "pseudomap": "1.0.2",
-                "yallist": "2.1.2"
-              }
-            },
-            "md5-hex": {
-              "version": "1.3.0",
-              "bundled": true,
-              "requires": {
-                "md5-o-matic": "0.1.1"
-              }
-            },
-            "md5-o-matic": {
-              "version": "0.1.1",
-              "bundled": true
-            },
-            "mem": {
-              "version": "1.1.0",
-              "bundled": true,
-              "requires": {
-                "mimic-fn": "1.1.0"
-              }
-            },
-            "merge-source-map": {
-              "version": "1.0.4",
-              "bundled": true,
-              "requires": {
-                "source-map": "0.5.6"
-              }
-            },
-            "micromatch": {
-              "version": "2.3.11",
-              "bundled": true,
-              "requires": {
-                "arr-diff": "2.0.0",
-                "array-unique": "0.2.1",
-                "braces": "1.8.5",
-                "expand-brackets": "0.1.5",
-                "extglob": "0.3.2",
-                "filename-regex": "2.0.1",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1",
-                "kind-of": "3.2.2",
-                "normalize-path": "2.1.1",
-                "object.omit": "2.0.1",
-                "parse-glob": "3.0.4",
-                "regex-cache": "0.4.3"
-              }
-            },
-            "mimic-fn": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "minimatch": {
-              "version": "3.0.4",
-              "bundled": true,
-              "requires": {
-                "brace-expansion": "1.1.8"
-              }
-            },
-            "minimist": {
-              "version": "0.0.8",
-              "bundled": true
-            },
-            "mkdirp": {
-              "version": "0.5.1",
-              "bundled": true,
-              "requires": {
-                "minimist": "0.0.8"
-              }
-            },
-            "ms": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "normalize-package-data": {
-              "version": "2.3.8",
-              "bundled": true,
-              "requires": {
-                "hosted-git-info": "2.4.2",
-                "is-builtin-module": "1.0.0",
-                "semver": "5.3.0",
-                "validate-npm-package-license": "3.0.1"
-              }
-            },
-            "normalize-path": {
-              "version": "2.1.1",
-              "bundled": true,
-              "requires": {
-                "remove-trailing-separator": "1.0.2"
-              }
-            },
-            "npm-run-path": {
-              "version": "2.0.2",
-              "bundled": true,
-              "requires": {
-                "path-key": "2.0.1"
-              }
-            },
-            "number-is-nan": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "bundled": true
-            },
-            "object.omit": {
-              "version": "2.0.1",
-              "bundled": true,
-              "requires": {
-                "for-own": "0.1.5",
-                "is-extendable": "0.1.1"
-              }
-            },
-            "once": {
-              "version": "1.4.0",
-              "bundled": true,
-              "requires": {
-                "wrappy": "1.0.2"
-              }
-            },
-            "optimist": {
-              "version": "0.6.1",
-              "bundled": true,
-              "requires": {
-                "minimist": "0.0.8",
-                "wordwrap": "0.0.3"
-              }
-            },
-            "os-homedir": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "os-locale": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "execa": "0.5.1",
-                "lcid": "1.0.0",
-                "mem": "1.1.0"
-              }
-            },
-            "p-finally": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "p-limit": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "p-locate": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "p-limit": "1.1.0"
-              }
-            },
-            "parse-glob": {
-              "version": "3.0.4",
-              "bundled": true,
-              "requires": {
-                "glob-base": "0.3.0",
-                "is-dotfile": "1.0.3",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1"
-              }
-            },
-            "parse-json": {
-              "version": "2.2.0",
-              "bundled": true,
-              "requires": {
-                "error-ex": "1.3.1"
-              }
-            },
-            "path-exists": {
-              "version": "2.1.0",
-              "bundled": true,
-              "requires": {
-                "pinkie-promise": "2.0.1"
-              }
-            },
-            "path-is-absolute": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "path-key": {
-              "version": "2.0.1",
-              "bundled": true
-            },
-            "path-parse": {
-              "version": "1.0.5",
-              "bundled": true
-            },
-            "path-type": {
-              "version": "1.1.0",
-              "bundled": true,
-              "requires": {
-                "graceful-fs": "4.1.11",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1"
-              }
-            },
-            "pify": {
-              "version": "2.3.0",
-              "bundled": true
-            },
-            "pinkie": {
-              "version": "2.0.4",
-              "bundled": true
-            },
-            "pinkie-promise": {
-              "version": "2.0.1",
-              "bundled": true,
-              "requires": {
-                "pinkie": "2.0.4"
-              }
-            },
-            "pkg-dir": {
-              "version": "1.0.0",
-              "bundled": true,
-              "requires": {
-                "find-up": "1.1.2"
-              },
-              "dependencies": {
-                "find-up": {
-                  "version": "1.1.2",
-                  "bundled": true,
-                  "requires": {
-                    "path-exists": "2.1.0",
-                    "pinkie-promise": "2.0.1"
-                  }
-                }
-              }
-            },
-            "preserve": {
-              "version": "0.2.0",
-              "bundled": true
-            },
-            "pseudomap": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "randomatic": {
-              "version": "1.1.7",
-              "bundled": true,
-              "requires": {
-                "is-number": "3.0.0",
-                "kind-of": "4.0.0"
-              },
-              "dependencies": {
-                "is-number": {
-                  "version": "3.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "kind-of": "3.2.2"
-                  },
-                  "dependencies": {
-                    "kind-of": {
-                      "version": "3.2.2",
-                      "bundled": true,
-                      "requires": {
-                        "is-buffer": "1.1.5"
-                      }
-                    }
-                  }
-                },
-                "kind-of": {
-                  "version": "4.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "is-buffer": "1.1.5"
-                  }
-                }
-              }
-            },
-            "read-pkg": {
-              "version": "1.1.0",
-              "bundled": true,
-              "requires": {
-                "load-json-file": "1.1.0",
-                "normalize-package-data": "2.3.8",
-                "path-type": "1.1.0"
-              }
-            },
-            "read-pkg-up": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "find-up": "1.1.2",
-                "read-pkg": "1.1.0"
-              },
-              "dependencies": {
-                "find-up": {
-                  "version": "1.1.2",
-                  "bundled": true,
-                  "requires": {
-                    "path-exists": "2.1.0",
-                    "pinkie-promise": "2.0.1"
-                  }
-                }
-              }
-            },
-            "regenerator-runtime": {
-              "version": "0.10.5",
-              "bundled": true
-            },
-            "regex-cache": {
-              "version": "0.4.3",
-              "bundled": true,
-              "requires": {
-                "is-equal-shallow": "0.1.3",
-                "is-primitive": "2.0.0"
-              }
-            },
-            "remove-trailing-separator": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "repeat-element": {
-              "version": "1.1.2",
-              "bundled": true
-            },
-            "repeat-string": {
-              "version": "1.6.1",
-              "bundled": true
-            },
-            "repeating": {
-              "version": "2.0.1",
-              "bundled": true,
-              "requires": {
-                "is-finite": "1.0.2"
-              }
-            },
-            "require-directory": {
-              "version": "2.1.1",
-              "bundled": true
-            },
-            "require-main-filename": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "resolve-from": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "right-align": {
-              "version": "0.1.3",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "align-text": "0.1.4"
-              }
-            },
-            "rimraf": {
-              "version": "2.6.1",
-              "bundled": true,
-              "requires": {
-                "glob": "7.1.2"
-              }
-            },
-            "semver": {
-              "version": "5.3.0",
-              "bundled": true
-            },
-            "set-blocking": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "signal-exit": {
-              "version": "3.0.2",
-              "bundled": true
-            },
-            "slide": {
-              "version": "1.1.6",
-              "bundled": true
-            },
-            "source-map": {
-              "version": "0.5.6",
-              "bundled": true
-            },
-            "spawn-wrap": {
-              "version": "1.3.7",
-              "bundled": true,
-              "requires": {
-                "foreground-child": "1.5.6",
-                "mkdirp": "0.5.1",
-                "os-homedir": "1.0.2",
-                "rimraf": "2.6.1",
-                "signal-exit": "3.0.2",
-                "which": "1.2.14"
-              }
-            },
-            "spdx-correct": {
-              "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "spdx-license-ids": "1.2.2"
-              }
-            },
-            "spdx-expression-parse": {
-              "version": "1.0.4",
-              "bundled": true
-            },
-            "spdx-license-ids": {
-              "version": "1.2.2",
-              "bundled": true
-            },
-            "string-width": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "is-fullwidth-code-point": "2.0.0",
-                "strip-ansi": "3.0.1"
-              },
-              "dependencies": {
-                "is-fullwidth-code-point": {
-                  "version": "2.0.0",
-                  "bundled": true
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "bundled": true,
-              "requires": {
-                "ansi-regex": "2.1.1"
-              }
-            },
-            "strip-bom": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "is-utf8": "0.2.1"
-              }
-            },
-            "strip-eof": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "test-exclude": {
-              "version": "4.1.1",
-              "bundled": true,
-              "requires": {
-                "arrify": "1.0.1",
-                "micromatch": "2.3.11",
-                "object-assign": "4.1.1",
-                "read-pkg-up": "1.0.1",
-                "require-main-filename": "1.0.1"
-              }
-            },
-            "to-fast-properties": {
-              "version": "1.0.3",
-              "bundled": true
-            },
-            "trim-right": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "uglify-js": {
-              "version": "2.8.29",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "source-map": "0.5.6",
-                "uglify-to-browserify": "1.0.2",
-                "yargs": "3.10.0"
-              },
-              "dependencies": {
-                "yargs": {
-                  "version": "3.10.0",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "camelcase": "1.2.1",
-                    "cliui": "2.1.0",
-                    "decamelize": "1.2.0",
-                    "window-size": "0.1.0"
-                  }
-                }
-              }
-            },
-            "uglify-to-browserify": {
-              "version": "1.0.2",
-              "bundled": true,
-              "optional": true
-            },
-            "validate-npm-package-license": {
-              "version": "3.0.1",
-              "bundled": true,
-              "requires": {
-                "spdx-correct": "1.0.2",
-                "spdx-expression-parse": "1.0.4"
-              }
-            },
-            "which": {
-              "version": "1.2.14",
-              "bundled": true,
-              "requires": {
-                "isexe": "2.0.0"
-              }
-            },
-            "which-module": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "window-size": {
-              "version": "0.1.0",
-              "bundled": true,
-              "optional": true
-            },
-            "wordwrap": {
-              "version": "0.0.3",
-              "bundled": true
-            },
-            "wrap-ansi": {
-              "version": "2.1.0",
-              "bundled": true,
-              "requires": {
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1"
-              },
-              "dependencies": {
-                "string-width": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "requires": {
-                    "code-point-at": "1.1.0",
-                    "is-fullwidth-code-point": "1.0.0",
-                    "strip-ansi": "3.0.1"
-                  }
-                }
-              }
-            },
-            "wrappy": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "write-file-atomic": {
-              "version": "1.3.4",
-              "bundled": true,
-              "requires": {
-                "graceful-fs": "4.1.11",
-                "imurmurhash": "0.1.4",
-                "slide": "1.1.6"
-              }
-            },
-            "y18n": {
-              "version": "3.2.1",
-              "bundled": true
-            },
-            "yallist": {
-              "version": "2.1.2",
-              "bundled": true
-            },
-            "yargs": {
-              "version": "8.0.2",
-              "bundled": true,
-              "requires": {
-                "camelcase": "4.1.0",
-                "cliui": "3.2.0",
-                "decamelize": "1.2.0",
-                "get-caller-file": "1.0.2",
-                "os-locale": "2.0.0",
-                "read-pkg-up": "2.0.0",
-                "require-directory": "2.1.1",
-                "require-main-filename": "1.0.1",
-                "set-blocking": "2.0.0",
-                "string-width": "2.0.0",
-                "which-module": "2.0.0",
-                "y18n": "3.2.1",
-                "yargs-parser": "7.0.0"
-              },
-              "dependencies": {
-                "camelcase": {
-                  "version": "4.1.0",
-                  "bundled": true
-                },
-                "cliui": {
-                  "version": "3.2.0",
-                  "bundled": true,
-                  "requires": {
-                    "string-width": "1.0.2",
-                    "strip-ansi": "3.0.1",
-                    "wrap-ansi": "2.1.0"
-                  },
-                  "dependencies": {
-                    "string-width": {
-                      "version": "1.0.2",
-                      "bundled": true,
-                      "requires": {
-                        "code-point-at": "1.1.0",
-                        "is-fullwidth-code-point": "1.0.0",
-                        "strip-ansi": "3.0.1"
-                      }
-                    }
-                  }
-                },
-                "load-json-file": {
-                  "version": "2.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "graceful-fs": "4.1.11",
-                    "parse-json": "2.2.0",
-                    "pify": "2.3.0",
-                    "strip-bom": "3.0.0"
-                  }
-                },
-                "path-type": {
-                  "version": "2.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "pify": "2.3.0"
-                  }
-                },
-                "read-pkg": {
-                  "version": "2.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "load-json-file": "2.0.0",
-                    "normalize-package-data": "2.3.8",
-                    "path-type": "2.0.0"
-                  }
-                },
-                "read-pkg-up": {
-                  "version": "2.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "find-up": "2.1.0",
-                    "read-pkg": "2.0.0"
-                  }
-                },
-                "strip-bom": {
-                  "version": "3.0.0",
-                  "bundled": true
-                },
-                "yargs-parser": {
-                  "version": "7.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "camelcase": "4.1.0"
-                  }
-                }
-              }
-            },
-            "yargs-parser": {
-              "version": "5.0.0",
-              "bundled": true,
-              "requires": {
-                "camelcase": "3.0.0"
-              },
-              "dependencies": {
-                "camelcase": {
-                  "version": "3.0.0",
-                  "bundled": true
-                }
-              }
-            }
-          }
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "requires": {
-            "wrappy": "1.0.2"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "pathval": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "supports-color": {
-          "version": "3.1.2",
-          "bundled": true,
-          "requires": {
-            "has-flag": "1.0.0"
-          }
-        },
-        "to-camel-case": {
-          "version": "1.0.0",
-          "bundled": true,
-          "requires": {
-            "to-space-case": "1.0.0"
-          }
-        },
-        "to-no-case": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "to-space-case": {
-          "version": "1.0.0",
-          "bundled": true,
-          "requires": {
-            "to-no-case": "1.0.2"
-          }
-        },
-        "topo": {
-          "version": "2.0.2",
-          "bundled": true,
-          "requires": {
-            "hoek": "4.1.1"
-          }
-        },
-        "type-detect": {
-          "version": "4.0.3",
-          "bundled": true
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true
-        }
+        "joi": "10.6.0"
       }
     },
     "text-encoding": {
@@ -3741,6 +2097,14 @@
       "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
       "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
       "dev": true
+    },
+    "topo": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
+      "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
+      "requires": {
+        "hoek": "4.2.0"
+      }
     },
     "type-detect": {
       "version": "4.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "swatchjs-koa",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -129,6 +129,11 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "function-arguments": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/function-arguments/-/function-arguments-1.0.8.tgz",
+      "integrity": "sha1-uaAdrKa4lO/4w9NoQDde2WNqbA8="
+    },
     "get-func-name": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
@@ -167,6 +172,11 @@
       "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
       "dev": true
     },
+    "hoek": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
+      "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
+    },
     "http-errors": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.1.tgz",
@@ -197,6 +207,27 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
       "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+    },
+    "isemail": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-2.2.1.tgz",
+      "integrity": "sha1-A1PT2aYpUQgMJiwqoKQrjqjp4qY="
+    },
+    "items": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/items/-/items-2.1.1.tgz",
+      "integrity": "sha1-i9FtnIOxlSneWuoyGsqtp4NkoZg="
+    },
+    "joi": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz",
+      "integrity": "sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==",
+      "requires": {
+        "hoek": "4.2.0",
+        "isemail": "2.2.1",
+        "items": "2.1.1",
+        "topo": "2.0.2"
+      }
     },
     "json3": {
       "version": "3.3.2",
@@ -2023,9 +2054,9 @@
       "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
     },
     "sinon": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-2.3.8.tgz",
-      "integrity": "sha1-Md4G/tj7o6Zx5XbdltClhjeW8lw=",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-2.4.1.tgz",
+      "integrity": "sha512-vFTrO9Wt0ECffDYIPSP/E5bBugt0UjcBQOfQUMh66xzkyPEnhl/vM2LRZi2ajuTdkH07sA6DzrM6KvdvGIH8xw==",
       "dev": true,
       "requires": {
         "diff": "3.2.0",
@@ -2053,45 +2084,12 @@
       }
     },
     "swatchjs": {
-      "version": "file:../swatchjs",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/swatchjs/-/swatchjs-0.1.4.tgz",
+      "integrity": "sha512-9E8M7uXnsjOX+TLKz4ZWWj8hD/2LLVKFuRFAdpoq6aw5Xl4kj2kq75Q3wtv4TzyF5vWEesRWbiU140gJrsPJqQ==",
       "requires": {
         "function-arguments": "1.0.8",
         "joi": "10.6.0"
-      },
-      "dependencies": {
-        "function-arguments": {
-          "version": "1.0.8",
-          "bundled": true
-        },
-        "hoek": {
-          "version": "4.2.0",
-          "bundled": true
-        },
-        "isemail": {
-          "version": "2.2.1",
-          "bundled": true
-        },
-        "items": {
-          "version": "2.1.1",
-          "bundled": true
-        },
-        "joi": {
-          "version": "10.6.0",
-          "bundled": true,
-          "requires": {
-            "hoek": "4.2.0",
-            "isemail": "2.2.1",
-            "items": "2.1.1",
-            "topo": "2.0.2"
-          }
-        },
-        "topo": {
-          "version": "2.0.2",
-          "bundled": true,
-          "requires": {
-            "hoek": "4.2.0"
-          }
-        }
       }
     },
     "text-encoding": {
@@ -2099,6 +2097,14 @@
       "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
       "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
       "dev": true
+    },
+    "topo": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
+      "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
+      "requires": {
+        "hoek": "4.2.0"
+      }
     },
     "type-detect": {
       "version": "4.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -129,11 +129,6 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
-    "function-arguments": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/function-arguments/-/function-arguments-1.0.8.tgz",
-      "integrity": "sha1-uaAdrKa4lO/4w9NoQDde2WNqbA8="
-    },
     "get-func-name": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
@@ -172,11 +167,6 @@
       "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
       "dev": true
     },
-    "hoek": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-      "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
-    },
     "http-errors": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.1.tgz",
@@ -207,27 +197,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
       "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-    },
-    "isemail": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isemail/-/isemail-2.2.1.tgz",
-      "integrity": "sha1-A1PT2aYpUQgMJiwqoKQrjqjp4qY="
-    },
-    "items": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/items/-/items-2.1.1.tgz",
-      "integrity": "sha1-i9FtnIOxlSneWuoyGsqtp4NkoZg="
-    },
-    "joi": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz",
-      "integrity": "sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==",
-      "requires": {
-        "hoek": "4.2.0",
-        "isemail": "2.2.1",
-        "items": "2.1.1",
-        "topo": "2.0.2"
-      }
     },
     "json3": {
       "version": "3.3.2",
@@ -2084,12 +2053,45 @@
       }
     },
     "swatchjs": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/swatchjs/-/swatchjs-0.1.2.tgz",
-      "integrity": "sha512-6Ho7RQqHHQbfR5ETylfCtsOaWnJfSa6ga4k27ENKu2Y11anA/A+XhSgkJVz1Y56JDie0f6H8WblBkg7xSbVIdQ==",
+      "version": "file:../swatchjs",
       "requires": {
         "function-arguments": "1.0.8",
         "joi": "10.6.0"
+      },
+      "dependencies": {
+        "function-arguments": {
+          "version": "1.0.8",
+          "bundled": true
+        },
+        "hoek": {
+          "version": "4.2.0",
+          "bundled": true
+        },
+        "isemail": {
+          "version": "2.2.1",
+          "bundled": true
+        },
+        "items": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "joi": {
+          "version": "10.6.0",
+          "bundled": true,
+          "requires": {
+            "hoek": "4.2.0",
+            "isemail": "2.2.1",
+            "items": "2.1.1",
+            "topo": "2.0.2"
+          }
+        },
+        "topo": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "hoek": "4.2.0"
+          }
+        }
       }
     },
     "text-encoding": {
@@ -2097,14 +2099,6 @@
       "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
       "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
       "dev": true
-    },
-    "topo": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
-      "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
-      "requires": {
-        "hoek": "4.2.0"
-      }
     },
     "type-detect": {
       "version": "4.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swatchjs-koa",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "KOA adapter for swatchjs",
   "main": "index.js",
   "scripts": {
@@ -31,7 +31,7 @@
     "sinon": "^2.3.4"
   },
   "dependencies": {
-    "swatchjs": "^0.1.3",
+    "swatchjs": "^0.1.4",
     "koa-router": "^7.0.0",
     "koa-compose": "^3.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
   },
   "dependencies": {
     "swatchjs": "^0.1.3",
-    "koa-router": "^7.2.1"
+    "koa-router": "^7.0.0",
+    "koa-compose": "^3.0.0"
   },
   "directories": {
     "lib": "lib",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "sinon": "^2.3.4"
   },
   "dependencies": {
-    "swatchjs": "^0.1.2",
+    "swatchjs": "^0.1.3",
     "koa-router": "^7.2.1"
   },
   "directories": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "sinon": "^2.3.4"
   },
   "dependencies": {
-    "swatchjs": "^0.1.0",
+    "swatchjs": "^0.1.2",
     "koa-router": "^7.2.1"
   },
   "directories": {

--- a/test/context.test.js
+++ b/test/context.test.js
@@ -1,0 +1,70 @@
+'use strict';
+
+const expect = require('chai').expect;
+
+const swatchCtx = require('../lib/context');
+
+describe('swatchCtx', () => {
+  const testKoaCtx = {
+    testValue: 10,
+    testAsyncValue: 20,
+    testErrorValue: 30,
+    testThrownValue: 40,
+  };
+
+  it('should successfully execute the auth adapter and return promise', (done) => {
+    const options = {
+      authAdapter: (koaCtx) => {
+        return Promise.resolve(koaCtx.testValue);
+      }
+    }
+
+    const ctx = swatchCtx(options);
+    ctx.authAdapter(testKoaCtx).then(res => {
+      expect(res).to.equal(10);
+      done();
+    })
+  });
+
+  it('should successfully promise-ify the auth adapter function', (done) => {
+    const options = {
+      authAdapter: (koaCtx) => {
+        return koaCtx.testAsyncValue;
+      }
+    }
+
+    const ctx = swatchCtx(options);
+    ctx.authAdapter(testKoaCtx).then(res => {
+      expect(res).to.equal(20);
+      done();
+    })
+  });
+
+  it('should handle rejected promises in the auth adapter function', (done) => {
+    const options = {
+      authAdapter: (koaCtx) => {
+        return Promise.reject(koaCtx.testErrorValue);
+      }
+    };
+
+    const ctx = swatchCtx(options);
+    ctx.authAdapter(testKoaCtx).catch(err => {
+      expect(err).to.equal(30);
+      done();
+    })
+  });
+
+  it('should handle thrown errors in the auth adapter function', (done) => {
+    const options = {
+      authAdapter: (koaCtx) => {
+        throw koaCtx.testThrownValue;
+      }
+    };
+
+    const ctx = swatchCtx(options);
+    ctx.authAdapter(testKoaCtx).catch(err => {
+      expect(err).to.equal(40);
+      done();
+    })
+  });
+});

--- a/test/defaults.test.js
+++ b/test/defaults.test.js
@@ -8,7 +8,9 @@ describe('defaults', () => {
   describe('options', () => {
     it('should include all default options', () => {
       const options = defaults();
-      expect(options).to.be.an('object').that.has.all.keys('verbs', 'prefix');
+      expect(options).to.be.an('object').that.has.all.keys(
+        'verbs', 'prefix', 'authAdapter'
+      );
     });
   });
 
@@ -53,4 +55,29 @@ describe('defaults', () => {
       expect(defaults({}).prefix).to.equal('/');
     });
   });
+
+  describe('authAdapter', () => {
+    it('should throw if authAdapter is passed, but is not a function', () => {
+      const options = {
+        authAdapter: 1,
+      };
+      expect(() => defaults(options)).to.throw();
+    });
+
+    it('should use the passed auth function', () => {
+      function authAdapter() {
+        return {
+          test: '100'
+        };
+      }
+      const options = {
+        authAdapter,
+      };
+      expect(defaults(options).authAdapter()).to.deep.equal({ test: '100' });
+    });
+
+    it('should use the default auth adapter if not specified', () => {
+      expect(defaults({}).authAdapter()).to.deep.equal({});
+    });
+  })
 });

--- a/test/handlers/handlers.test.js
+++ b/test/handlers/handlers.test.js
@@ -33,7 +33,10 @@ describe('handlers', () => {
 
           let param = { key: true };
           const middleware = [
-            (ctx, auth) => { param = auth; },
+            (ctx, next) => {
+              param = ctx.swatchJs.auth;
+              next();
+            },
           ]
 
           invokeHandler(fn, verb, expected, done, middleware).then(() => {
@@ -59,7 +62,7 @@ describe('handlers', () => {
             error: 'middleware_error',
           };
           const middleware = [
-            (ctx, auth) => { throw 'middleware_error'; },
+            (ctx, next) => { throw 'middleware_error'; },
           ]
 
           invokeHandler(fn, verb, expected, done, middleware);
@@ -96,7 +99,9 @@ function invokeHandler(fn, verb, expected, done, middleware) {
     },
   });
   const swatchCtx = {
-    authAdapter: function() { return {}; },
+    authAdapter: function() {
+      return Promise.resolve({});
+    },
   };
   const handler = handlers[verb](swatchCtx, model[0]);
 

--- a/test/handlers/handlers.test.js
+++ b/test/handlers/handlers.test.js
@@ -40,12 +40,17 @@ describe('handlers', () => {
 
 function invokeHandler(fn, verb, expected, done) {
   const params = {a: 1, b: 2};
+  const request = {
+    get body() {
+      return params;
+    },
+  };
   const ctx = {
     get query() {
       return params;
     },
-    get body() {
-      return params;
+    get request() {
+      return request;
     },
     set body(res) {
       expect(res).to.deep.equal(expected);
@@ -56,7 +61,8 @@ function invokeHandler(fn, verb, expected, done) {
   const model = swatch({
     fn: fn,
   });
-  const handler = handlers[verb](model[0]);
+  const swatchCtx = {};
+  const handler = handlers[verb](swatchCtx, model[0]);
 
   handler(ctx);
 }

--- a/test/handlers/handlers.test.js
+++ b/test/handlers/handlers.test.js
@@ -61,7 +61,9 @@ function invokeHandler(fn, verb, expected, done) {
   const model = swatch({
     fn: fn,
   });
-  const swatchCtx = {};
+  const swatchCtx = {
+    authAdapter: function() { return {}; },
+  };
   const handler = handlers[verb](swatchCtx, model[0]);
 
   handler(ctx);


### PR DESCRIPTION
Add a property on the Swatch-KOA API signature. Client can pass a custom function which will parse the request ctx and generate an 'auth ctx' object with custom auth information.

Also, updates the request handling pipeline to run any middleware functions as specified by the individual method before actually running the handler.  Pairs with https://github.com/builtforme/swatchjs/pull/4