### PR TITLE
Fixes to Swatch KOA middleware to support handlers w Promise

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -42,24 +42,21 @@ function defaultAuthAdapter(authAdapter) {
   return authMiddleware;
 
   function authMiddleware(koaCtx, next) {
-    try {
-      // Call the auth adapter function, allowing async
-      Promise.resolve(
-        authAdapterFn(koaCtx)
-      ).then(auth => {
-        // Successful auth is set on swatchCtx
-        if (!koaCtx.swatchCtx) {
-          koaCtx.swatchCtx = {};
-        }
-        koaCtx.swatchCtx.auth = auth;
+    return new Promise(resolve => {
+      resolve(authAdapterFn(koaCtx))
+    }).then(auth => {
+      // Successful auth is set on swatchCtx
+      if (!koaCtx.swatchCtx) {
+        koaCtx.swatchCtx = {};
+      }
+      koaCtx.swatchCtx.auth = auth;
 
-        // Continue chain of handlers
-        next();
-      });
-    } catch (error) {
+      // Continue chain of handlers
+      return next();
+    }).catch(error => {
       // Auth error should trigger failure response
       response.errorResponse(koaCtx, error);
-    }
+    });
   };
 }
 

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -41,6 +41,10 @@ function defaultAuthAdapter(authAdapter) {
 
   return authMiddleware;
 
+  function noopAuthAdapter() {
+    return {};
+  }
+
   function authMiddleware(koaCtx, next) {
     return new Promise(resolve => {
       resolve(authAdapterFn(koaCtx))
@@ -58,10 +62,6 @@ function defaultAuthAdapter(authAdapter) {
       response.errorResponse(koaCtx, error);
     });
   };
-}
-
-function noopAuthAdapter() {
-  return {};
 }
 
 module.exports = defaults;

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -41,10 +41,6 @@ function defaultAuthAdapter(authAdapter) {
 
   return authMiddleware;
 
-  function noopAuthAdapter() {
-    return {};
-  }
-
   function authMiddleware(koaCtx, next) {
     try {
       // Call the auth adapter function, allowing async
@@ -65,6 +61,10 @@ function defaultAuthAdapter(authAdapter) {
       response.errorResponse(koaCtx, error);
     }
   };
+}
+
+function noopAuthAdapter() {
+  return {};
 }
 
 module.exports = defaults;

--- a/lib/expose.js
+++ b/lib/expose.js
@@ -27,11 +27,11 @@ function expose(app, methods, options) {
           return wrapMiddleware(fn);
         })
       );
+      const handler = middleware.concat(
+        [handlers[verb](method)]
+      );
 
-      const handler = handlers[verb](method);
-      const handlerList = middleware.concat([handler]);
-
-      router[verb](path, ...handlerList);
+      router[verb](path, ...handler);
     }
   }
 

--- a/lib/expose.js
+++ b/lib/expose.js
@@ -27,11 +27,10 @@ function expose(app, methods, options) {
           return wrapMiddleware(fn);
         })
       );
-      const handler = middleware.concat(
-        [handlers[verb](method)]
-      );
+      const handler = handlers[verb](method);
+      const handlerList = middleware.concat([handler]);
 
-      router[verb](path, ...handler);
+      router[verb](path, ...handlerList);
     }
   }
 

--- a/lib/expose.js
+++ b/lib/expose.js
@@ -27,6 +27,7 @@ function expose(app, methods, options) {
           return wrapMiddleware(fn);
         })
       );
+
       const handler = handlers[verb](method);
       const handlerList = middleware.concat([handler]);
 

--- a/lib/handlers/handler.js
+++ b/lib/handlers/handler.js
@@ -3,14 +3,13 @@
 const response = require('../response');
 
 function handler(koaCtx, params, method) {
-  return Promise.resolve(params)
-    .then(args => {
-      return method.handle(args);
-    }).then(result => {
-      response.successResponse(koaCtx, result);
-    }).catch(error => {
-      response.errorResponse(koaCtx, error);
-    });
+  return new Promise(resolve => {
+    resolve(method.handle(params))
+  }).then(result => {
+    response.successResponse(koaCtx, result);
+  }).catch(error => {
+    response.errorResponse(koaCtx, error);
+  });
 }
 
 module.exports = handler;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "swatchjs-koa",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swatchjs-koa",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "KOA adapter for swatchjs",
   "main": "index.js",
   "scripts": {

--- a/test/defaults.test.js
+++ b/test/defaults.test.js
@@ -100,10 +100,10 @@ describe('defaults', () => {
       };
 
       const emptyCtx = {};
-      defaults(options).authAdapter(emptyCtx);
-
-      expect(emptyCtx.body.ok).to.equal(false);
-      expect(emptyCtx.body.error).to.equal('auth_error');
+      defaults(options).authAdapter(emptyCtx).then(() => {
+        expect(emptyCtx.body.ok).to.equal(false);
+        expect(emptyCtx.body.error).to.equal('auth_error');
+      });
     });
   })
 });

--- a/test/expose.test.js
+++ b/test/expose.test.js
@@ -186,7 +186,7 @@ describe('expose', () => {
             return new Promise((resolve) => {
               setTimeout(() => {
                 resolve(100);
-              }, 1);
+              }, 500);
             });
           }
         },

--- a/test/expose.test.js
+++ b/test/expose.test.js
@@ -72,7 +72,7 @@ describe('expose', () => {
     });
   });
 
-  it('should support an auth adapter with middleware', () => {
+  it('should support an auth adapter with middleware', (done) => {
     // Define an authAdapter that returns a simple auth object
     //  Define one middleware fn to copy auth info to response body
     const app = new koa();
@@ -114,7 +114,7 @@ describe('expose', () => {
       });
   });
 
-  it('should support an async auth adapter with middleware', () => {
+  it('should support an async auth adapter with middleware', (done) => {
     // Define an authAdapter that returns a simple auth object
     //  Define one middleware fn to copy auth info to response body
     const app = new koa();
@@ -156,7 +156,84 @@ describe('expose', () => {
       });
   });
 
-  it('should return an error when auth adapter throws an error', () => {
+  it('should return an error when handler throws an error', (done) => {
+    // Define a sync handler that throws an exception
+    const app = new koa();
+    const model = swatch({
+      "add": {
+        handler: () => {
+          throw 'sync_whoops';
+        },
+      },
+    });
+
+    expose(app, model);
+
+    request(http.createServer(app.callback()))
+      .get('/add')
+      .expect(200)
+      .end((err, res) => {
+        expect(err).to.equal(null);
+        expect(res.body.ok).to.equal(false);
+        expect(res.body.error).to.equal('sync_whoops');
+        done();
+      });
+    });
+
+    it('should return success from an async handler', (done) => {
+      const app = new koa();
+      const model = swatch({
+        "add": {
+          handler: () => {
+            return new Promise((resolve) => {
+              setTimeout(() => {
+                resolve(100);
+              }, 1);
+            });
+          }
+        },
+      });
+
+      expose(app, model);
+
+      request(http.createServer(app.callback()))
+        .get('/add')
+        .expect(200)
+        .end((err, res) => {
+          expect(err).to.equal(null);
+          expect(res.body.ok).to.equal(true);
+          expect(res.body.error).to.equal(100);
+          done();
+        });
+    });
+
+  it('should return an error when handler throws an error inside a promise', (done) => {
+    // Define an async function that throws a exception from inside a promise
+    const app = new koa();
+    const model = swatch({
+      "add": {
+        handler: () => {
+          return Promise.resolve('async_whoops').then(msg => {
+            throw msg;
+          });
+        },
+      },
+    });
+
+    expose(app, model);
+
+    request(http.createServer(app.callback()))
+      .get('/add')
+      .expect(200)
+      .end((err, res) => {
+        expect(err).to.equal(null);
+        expect(res.body.ok).to.equal(false);
+        expect(res.body.error).to.equal('async_whoops');
+        done();
+      });
+    });
+
+  it('should return an error when auth adapter throws an error', (done) => {
     // Define an authAdapter that throws an exception
     //  Define one middleware fn that should not run
     const app = new koa();
@@ -195,7 +272,7 @@ describe('expose', () => {
       });
     });
 
-  it('should return an error when any middleware throws an error', () => {
+  it('should return an error when any middleware throws an error', (done) => {
     // Define an authAdapter that works correctly
     //  Define one middleware fn that throws an error
     const app = new koa();

--- a/test/expose.test.js
+++ b/test/expose.test.js
@@ -317,7 +317,7 @@ describe('expose', () => {
         middleware: [
           (ctx, next) => {
             return Promise.resolve(2000).then(val => {
-              return next();
+              next();
             });
           }
         ]
@@ -348,8 +348,8 @@ describe('expose', () => {
         },
         middleware: [
           (ctx, next) => {
-            return Promise.resolve(2000).then(val => {
-              return next();
+            return Promise.resolve(3000).then(val => {
+              next();
             });
           }
         ]


### PR DESCRIPTION
Update how KOA Swatch middleware wrappers and handler wrapper use Promises
Add tests for a bunch of scenarios that are actually being used in DMPS