### PR TITLE
Skip authentication when individual methods have flag set

### DIFF
--- a/lib/expose.js
+++ b/lib/expose.js
@@ -21,7 +21,9 @@ function expose(app, methods, options) {
 
       const path = `${options.prefix}${method.name}`;
 
-      const adapter = [options.authAdapter];
+      const adapter = method.noAuth ?
+        [initSwatchCtx] :
+        [options.authAdapter];
       const middleware = adapter.concat(
         method.middleware.map(fn => {
           return wrapMiddleware(fn);
@@ -37,6 +39,14 @@ function expose(app, methods, options) {
 
   app.use(router.routes());
 }
+
+function initSwatchCtx(koaCtx, next) {
+  // Create the swatchCtx object on the KOA ctx
+  koaCtx.swatchCtx = {};
+
+  // Continue chain of handlers
+  return next();
+};
 
 function wrapMiddleware(fn) {
   return wrapper;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "swatchjs-koa",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3077,9 +3077,9 @@
       }
     },
     "swatchjs": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/swatchjs/-/swatchjs-0.1.4.tgz",
-      "integrity": "sha512-9E8M7uXnsjOX+TLKz4ZWWj8hD/2LLVKFuRFAdpoq6aw5Xl4kj2kq75Q3wtv4TzyF5vWEesRWbiU140gJrsPJqQ==",
+      "version": "0.1.36",
+      "resolved": "https://registry.npmjs.org/swatchjs/-/swatchjs-0.1.36.tgz",
+      "integrity": "sha1-eVh8UsY1RCMYDaqpL2jHHxQR8cE=",
       "requires": {
         "function-arguments": "1.0.8",
         "joi": "10.6.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swatchjs-koa",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "KOA adapter for swatchjs",
   "main": "index.js",
   "scripts": {
@@ -38,7 +38,7 @@
     "supertest": "^3.0.0"
   },
   "dependencies": {
-    "swatchjs": "^0.1.4",
+    "swatchjs": "^0.1.36",
     "koa-router": "^7.0.0"
   },
   "directories": {


### PR DESCRIPTION
Update swatch-koa to skip the authorization adapter when building the chain of middleware for each method. Instead just pass a simple method to init the swatchCtx and continue the chain.