### PR TITLE
Use Node 6 for CircleCI Builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
   codecov_report_code_coverage:
     docker:
       # specify the version you desire here
-      - image: circleci/node:7.10
+      - image: circleci/node:6
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images
@@ -69,7 +69,7 @@ jobs:
   coveralls_report_code_coverage:
     docker:
       # specify the version you desire here
-      - image: circleci/node:7.10
+      - image: circleci/node:6
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images
@@ -101,7 +101,7 @@ jobs:
   version:
     docker:
       # specify the version you desire here
-      - image: circleci/node:7.10
+      - image: circleci/node:6
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images
@@ -131,7 +131,7 @@ jobs:
   publish:
     docker:
       # specify the version you desire here
-      - image: circleci/node:7.10
+      - image: circleci/node:6
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/node:6.3
+      - image: circleci/node:6
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/node:7.10
+      - image: circleci/node:6.3
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "swatchjs-koa",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swatchjs-koa",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "KOA adapter for swatchjs",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Using Node7 causes one of the unit tests to fail for as-yet unknown reasons. We should fix that in the future and also add CI to cover multiple versions of node. But that's beyond the scope of the PR at hand.