### PR TITLE
Update library to support swatchjs metadata changes

### DIFF
--- a/lib/expose.js
+++ b/lib/expose.js
@@ -33,14 +33,16 @@ function expose(app, methods, opts) {
   function addMethod(method) {
     function addRoute(supportedVerb) {
       const verb = supportedVerb.trim();
-
       const path = `${options.prefix}${method.name}`;
 
-      const adapter = method.noAuth ?
+      const noAuth = method.metadata.noAuth || false;
+      const methodMiddleware = method.metadata.middleware || [];
+
+      const adapter = noAuth ?
         [initSwatchCtx] :
         [initSwatchCtx, options.authAdapter];
       const middleware = adapter.concat(
-        method.middleware.map(wrapMiddleware),
+        methodMiddleware.map(wrapMiddleware),
       );
 
       const handler = handlers[verb](method);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "swatchjs-koa",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6617,9 +6617,9 @@
       "dev": true
     },
     "swatchjs": {
-      "version": "0.1.36",
-      "resolved": "https://registry.npmjs.org/swatchjs/-/swatchjs-0.1.36.tgz",
-      "integrity": "sha1-eVh8UsY1RCMYDaqpL2jHHxQR8cE=",
+      "version": "0.1.37",
+      "resolved": "https://registry.npmjs.org/swatchjs/-/swatchjs-0.1.37.tgz",
+      "integrity": "sha1-AW9Msed/9PiaFCTkKdC+39m7eWc=",
       "requires": {
         "function-arguments": "1.0.8",
         "joi": "10.6.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "swatchjs-koa",
-  "version": "0.1.20",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6617,9 +6617,9 @@
       "dev": true
     },
     "swatchjs": {
-      "version": "0.1.37",
-      "resolved": "https://registry.npmjs.org/swatchjs/-/swatchjs-0.1.37.tgz",
-      "integrity": "sha1-AW9Msed/9PiaFCTkKdC+39m7eWc=",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/swatchjs/-/swatchjs-0.2.0.tgz",
+      "integrity": "sha1-dALog6v1tSErPnT+WQZswT05Ukg=",
       "requires": {
         "function-arguments": "1.0.8",
         "joi": "10.6.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swatchjs-koa",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "description": "KOA adapter for swatchjs",
   "main": "dist/index.js",
   "scripts": {
@@ -58,7 +58,7 @@
     "babel-polyfill": "^6.23.0",
     "babel-runtime": "^6.25.0",
     "koa-router": "^7.2.1",
-    "swatchjs": "^0.1.36"
+    "swatchjs": "^0.1.37"
   },
   "directories": {
     "lib": "lib",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swatchjs-koa",
-  "version": "0.1.20",
+  "version": "0.2.0",
   "description": "KOA adapter for swatchjs",
   "main": "dist/index.js",
   "scripts": {
@@ -58,7 +58,7 @@
     "babel-polyfill": "^6.23.0",
     "babel-runtime": "^6.25.0",
     "koa-router": "^7.2.1",
-    "swatchjs": "^0.1.37"
+    "swatchjs": "^0.2.0"
   },
   "directories": {
     "lib": "lib",

--- a/test/expose.test.js
+++ b/test/expose.test.js
@@ -78,14 +78,16 @@ describe('expose', () => {
     const model = swatch({
       add: {
         handler: () => (10),
-        middleware: [
-          (ctx) => {
-            ctx.body = {
-              id: ctx.swatchCtx.auth.id,
-              auth: ctx.swatchCtx.auth.auth,
-            };
-          },
-        ],
+        metadata: {
+          middleware: [
+            (ctx) => {
+              ctx.body = {
+                id: ctx.swatchCtx.auth.id,
+                auth: ctx.swatchCtx.auth.auth,
+              };
+            },
+          ],
+        },
       },
     });
     const options = {
@@ -116,14 +118,16 @@ describe('expose', () => {
     const model = swatch({
       add: {
         handler: () => (10),
-        noAuth: true,
-        middleware: [
-          (ctx) => {
-            ctx.body = {
-              exists: Boolean(ctx.swatchCtx.auth),
-            };
-          },
-        ],
+        metadata: {
+          noAuth: true,
+          middleware: [
+            (ctx) => {
+              ctx.body = {
+                exists: Boolean(ctx.swatchCtx.auth),
+              };
+            },
+          ],
+        },
       },
     });
     const options = {
@@ -152,14 +156,16 @@ describe('expose', () => {
     const model = swatch({
       add: {
         handler: () => (10),
-        middleware: [
-          (ctx) => {
-            ctx.body = {
-              id: ctx.swatchCtx.auth.id,
-              auth: ctx.swatchCtx.auth.auth,
-            };
-          },
-        ],
+        metadata: {
+          middleware: [
+            (ctx) => {
+              ctx.body = {
+                id: ctx.swatchCtx.auth.id,
+                auth: ctx.swatchCtx.auth.auth,
+              };
+            },
+          ],
+        },
       },
     });
     const options = {
@@ -268,14 +274,16 @@ describe('expose', () => {
     const model = swatch({
       add: {
         handler: () => (10),
-        middleware: [
-          (ctx) => {
-            ctx.body = {
-              id: ctx.swatchCtx.auth.id,
-              auth: ctx.swatchCtx.auth.auth,
-            };
-          },
-        ],
+        metadata: {
+          middleware: [
+            (ctx) => {
+              ctx.body = {
+                id: ctx.swatchCtx.auth.id,
+                auth: ctx.swatchCtx.auth.auth,
+              };
+            },
+          ],
+        },
       },
     });
     const options = {
@@ -304,11 +312,13 @@ describe('expose', () => {
     const model = swatch({
       add: {
         handler: () => (10),
-        middleware: [
-          () => {
-            throw new Error('invalid_middleware_oops');
-          },
-        ],
+        metadata: {
+          middleware: [
+            () => {
+              throw new Error('invalid_middleware_oops');
+            },
+          ],
+        },
       },
     });
     const options = {
@@ -336,12 +346,14 @@ describe('expose', () => {
     const model = swatch({
       add: {
         handler: () => (500),
-        middleware: [
-          (ctx, next) => {
-            ctx.swatchCtx.value = 2000;
-            next();
-          },
-        ],
+        metadata: {
+          middleware: [
+            (ctx, next) => {
+              ctx.swatchCtx.value = 2000;
+              next();
+            },
+          ],
+        },
       },
     });
 
@@ -369,12 +381,14 @@ describe('expose', () => {
             }, 100);
           }).then(val => (val * 5))
         ),
-        middleware: [
-          async (ctx, next) => {
-            ctx.swatchCtx.value = 3000;
-            await next();
-          },
-        ],
+        metadata: {
+          middleware: [
+            async (ctx, next) => {
+              ctx.swatchCtx.value = 3000;
+              await next();
+            },
+          ],
+        },
       },
     });
 
@@ -396,14 +410,16 @@ describe('expose', () => {
     const model = swatch({
       add: {
         handler: () => (1000),
-        middleware: [
-          async (ctx, next) => {
-            const result = await Promise.resolve(2000);
-            ctx.swatchCtx.value = result;
+        metadata: {
+          middleware: [
+            async (ctx, next) => {
+              const result = await Promise.resolve(2000);
+              ctx.swatchCtx.value = result;
 
-            await next();
-          },
-        ],
+              await next();
+            },
+          ],
+        },
       },
     });
 
@@ -431,14 +447,16 @@ describe('expose', () => {
             }, 100);
           }).then(val => (val * 2))
         ),
-        middleware: [
-          async (ctx, next) => {
-            const result = await Promise.resolve(3000);
-            ctx.swatchCtx.value = result;
+        metadata: {
+          middleware: [
+            async (ctx, next) => {
+              const result = await Promise.resolve(3000);
+              ctx.swatchCtx.value = result;
 
-            await next();
-          },
-        ],
+              await next();
+            },
+          ],
+        },
       },
     });
 


### PR DESCRIPTION
Now that swatch API declarations have a new schema (https://github.com/builtforme/swatchjs/pull/22), update this package to support the new schema