### PR TITLE
If Error Details Present, Return Them

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,6 +10,7 @@
         "ecmaFeatures": {}
     },
     "rules": {
-        "no-param-reassign": ["error", { "props": false }]
+        "no-param-reassign": ["error", { "props": false }],
+        "no-throw-literal": 0
     }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -11,6 +11,6 @@
     },
     "rules": {
         "no-param-reassign": ["error", { "props": false }],
-        "no-throw-literal": 0
+        "no-throw-literal": "off"
     }
 }

--- a/lib/response.js
+++ b/lib/response.js
@@ -13,6 +13,7 @@ function errorResponse(ctx, error) {
   ctx.body = {
     ok: false,
     error: (error && error.message) || error,
+    details: (error && error.details) || undefined,
   };
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "swatchjs-koa",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6617,9 +6617,9 @@
       "dev": true
     },
     "swatchjs": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/swatchjs/-/swatchjs-0.2.1.tgz",
-      "integrity": "sha1-gkdYjcUi4lT3OZ7Aw+7L9DIP5zY=",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/swatchjs/-/swatchjs-0.2.2.tgz",
+      "integrity": "sha1-0qBR+3rt2/8DoR1AUWvhfH1jDQM=",
       "requires": {
         "function-arguments": "1.0.8",
         "joi": "10.6.0"

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "babel-polyfill": "^6.23.0",
     "babel-runtime": "^6.25.0",
     "koa-router": "^7.2.1",
-    "swatchjs": "^0.2.0"
+    "swatchjs": "^0.2.2"
   },
   "directories": {
     "lib": "lib",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swatchjs-koa",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "KOA adapter for swatchjs",
   "main": "dist/index.js",
   "scripts": {

--- a/test/handlers/handlers.test.js
+++ b/test/handlers/handlers.test.js
@@ -34,7 +34,8 @@ function invokeHandler(fn, verb, expected) {
 function invokeErrorHandler(fn, verb) {
   const expected = {
     ok: false,
-    error: 'some_error: 3',
+    error: 'An error message',
+    details: 'This is a fake error meant to test stuff. a=1, b=2',
   };
   return invokeHandler(fn, verb, expected);
 }
@@ -61,7 +62,10 @@ describe('handlers', () => {
 
         it('should write a JSON error response if function fails with Error', (done) => {
           const fn = (a, b) => {
-            throw new Error(`some_error: ${a + b}`);
+            throw {
+              message: 'An error message',
+              details: `This is a fake error meant to test stuff. a=${a}, b=${b}`,
+            };
           };
           invokeErrorHandler(fn, verb).then(done);
         });


### PR DESCRIPTION
This PR brings forward the changes to expose more detailed error messages that were made in https://github.com/builtforme/swatchjs/pull/25, to actually have Koa return them.