### PR TITLE
Demo: Swallow Exception

### DIFF
--- a/test/handlers/handlers.test.js
+++ b/test/handlers/handlers.test.js
@@ -34,7 +34,7 @@ function invokeHandler(fn, verb, expected) {
 function invokeErrorHandler(fn, verb) {
   const expected = {
     ok: false,
-    error: 'some_error: 3',
+    error: 'some_error: 4',
   };
   return invokeHandler(fn, verb, expected);
 }


### PR DESCRIPTION
This PR is to demonstrate how we're swallowing exceptions, even `expect`-based exceptions, and silently failing.

The problem is with this line: https://github.com/builtforme/swatchjs-koa/blob/master/test/handlers/handlers.test.js#L20