### PR TITLE
Refactor to run validation first before middleware

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -1,7 +1,7 @@
 const handlers = require('./handlers');
 const response = require('./response');
 
-const SUPPORTED_VERBS = Object.keys(handlers);
+const SUPPORTED_VERBS = ['get', 'post'];
 
 function defaultVerbs(requested) {
   if (requested && !(requested instanceof Array)) {

--- a/lib/expose.js
+++ b/lib/expose.js
@@ -13,7 +13,7 @@ async function initSwatchCtx(koaCtx, next) {
 }
 
 function wrapMiddleware(fn) {
-  async function wrapper(koaCtx, next) {
+  async function middlewareWrapper(koaCtx, next) {
     try {
       await fn(koaCtx, next);
     } catch (error) {
@@ -22,7 +22,25 @@ function wrapMiddleware(fn) {
     }
   }
 
-  return wrapper;
+  return middlewareWrapper;
+}
+
+function validationMiddleware(validateFn, verb) {
+  async function validationWrapper(koaCtx, next) {
+    try {
+      // Get the params from request body and validate
+      //  Updates koaCtx.swatchCtx with validated params
+      const requestParams = handlers[verb](koaCtx);
+      validateFn(koaCtx, requestParams);
+
+      await next();
+    } catch (error) {
+      // Validation error should trigger failure response
+      response.errorResponse(koaCtx, error);
+    }
+  }
+
+  return validationWrapper;
 }
 
 function expose(app, methods, opts) {
@@ -35,17 +53,20 @@ function expose(app, methods, opts) {
       const verb = supportedVerb.trim();
       const path = `${options.prefix}${method.name}`;
 
-      const noAuth = method.metadata.noAuth || false;
-      const methodMiddleware = method.metadata.middleware || [];
+      const noAuth = method.metadata.noAuth;
+      const methodMiddleware = method.metadata.middleware;
 
       const adapter = noAuth ?
         [initSwatchCtx] :
         [initSwatchCtx, options.authAdapter];
-      const middleware = adapter.concat(
+      const validator = adapter.concat(
+        [validationMiddleware(method.validate, verb)],
+      );
+      const middleware = validator.concat(
         methodMiddleware.map(wrapMiddleware),
       );
 
-      const handler = handlers[verb](method);
+      const handler = handlers.handler(method.handle);
       const handlerList = middleware.concat([handler]);
 
       router[verb](path, ...handlerList);

--- a/lib/handlers/get.js
+++ b/lib/handlers/get.js
@@ -1,11 +1,5 @@
-const handler = require('./handler');
-
-function get(method) {
-  function getHandler(koaCtx) {
-    return handler(koaCtx, koaCtx.query, method);
-  }
-
-  return getHandler;
+function get(koaCtx) {
+  return koaCtx.query;
 }
 
 module.exports = get;

--- a/lib/handlers/handler.js
+++ b/lib/handlers/handler.js
@@ -1,12 +1,16 @@
 const response = require('../response');
 
-async function handler(koaCtx, params, method) {
-  try {
-    const result = await method.handle(params);
-    response.successResponse(koaCtx, result);
-  } catch (error) {
-    response.errorResponse(koaCtx, error);
+function handler(requestHandler) {
+  async function handleRequest(koaCtx) {
+    try {
+      const result = await requestHandler(koaCtx);
+      response.successResponse(koaCtx, result);
+    } catch (error) {
+      response.errorResponse(koaCtx, error);
+    }
   }
+
+  return handleRequest;
 }
 
 module.exports = handler;

--- a/lib/handlers/index.js
+++ b/lib/handlers/index.js
@@ -1,9 +1,9 @@
 const get = require('./get');
 const post = require('./post');
+const handler = require('./handler');
 
-const HANDLERS = {
+module.exports = {
   get,
   post,
+  handler,
 };
-
-module.exports = HANDLERS;

--- a/lib/handlers/post.js
+++ b/lib/handlers/post.js
@@ -1,11 +1,5 @@
-const handler = require('./handler');
-
-function post(method) {
-  function postHandler(koaCtx) {
-    return handler(koaCtx, koaCtx.request.body, method);
-  }
-
-  return postHandler;
+function post(koaCtx) {
+  return koaCtx.request.body;
 }
 
 module.exports = post;

--- a/test/defaults.test.js
+++ b/test/defaults.test.js
@@ -1,6 +1,5 @@
 const expect = require('chai').expect;
 const defaults = require('../lib/defaults');
-const handlers = require('../lib/handlers');
 
 describe('defaults', () => {
   describe('options', () => {
@@ -36,7 +35,7 @@ describe('defaults', () => {
     });
 
     it('should use the default verbs if a list is not passed in', () => {
-      expect(defaults().verbs).to.deep.equal(Object.keys(handlers));
+      expect(defaults().verbs).to.deep.equal(['get', 'post']);
     });
   });
 

--- a/test/handlers/handlers.test.js
+++ b/test/handlers/handlers.test.js
@@ -1,75 +1,37 @@
 const expect = require('chai').expect;
-const swatch = require('swatchjs');
 const handlers = require('../../lib/handlers');
-
-function invokeHandler(fn, verb, expected) {
-  const params = { a: 1, b: 2 };
-  const request = {
-    get body() {
-      return params;
-    },
-  };
-  const koaCtx = {
-    get query() {
-      return params;
-    },
-    get request() {
-      return request;
-    },
-    set body(res) {
-      expect(res).to.deep.equal(expected);
-    },
-  };
-
-  const model = swatch({
-    fn: {
-      handler: fn,
-    },
-  });
-  const handler = handlers[verb](model[0]);
-
-  return handler(koaCtx);
-}
-
-function invokeErrorHandler(fn, verb) {
-  const expected = {
-    ok: false,
-    error: 'An error message',
-    details: 'This is a fake error meant to test stuff. a=1, b=2',
-  };
-  return invokeHandler(fn, verb, expected);
-}
 
 describe('handlers', () => {
   describe('index', () => {
     it('should contain all verbs', () => {
-      expect(handlers).to.be.an('object').that.has.all.keys('get', 'post');
+      expect(handlers).to.be.an('object').that.has.all.keys('get', 'post', 'handler');
     });
   });
 
   describe('verbs', () => {
-    Object.keys(handlers).forEach((verb) => {
-      describe(verb, () => {
-        it('should write a JSON success response if function succeeds', (done) => {
-          const fn = (a, b) => a + b;
-          const expected = {
-            ok: true,
-            result: 3,
-          };
+    const params = { a: 1, b: 2 };
 
-          invokeHandler(fn, verb, expected).then(done);
-        });
+    it('should get query params from a GET request', () => {
+      const getCtx = {
+        get query() {
+          return params;
+        },
+      };
+      expect(handlers.get(getCtx)).to.deep.equal(params);
+    });
 
-        it('should write a JSON error response if function fails with Error', (done) => {
-          const fn = (a, b) => {
-            throw {
-              message: 'An error message',
-              details: `This is a fake error meant to test stuff. a=${a}, b=${b}`,
-            };
-          };
-          invokeErrorHandler(fn, verb).then(done);
-        });
-      });
+    it('should get query params from a POST request', () => {
+      const request = {
+        get body() {
+          return params;
+        },
+      };
+      const postCtx = {
+        get request() {
+          return request;
+        },
+      };
+      expect(handlers.post(postCtx)).to.deep.equal(params);
     });
   });
 });


### PR DESCRIPTION
Update swatch-koa to support swatch PR https://github.com/builtforme/swatchjs/pull/24

Now, when building the pipe of middleware, swatch-koa will first run the authentication check, then run the validation for the method, which adds the params to the swatch ctx, then the client-specified middleware, and finally the handler.

This will allow consumers to write middleware that has access to the validated parameters