### PR TITLE
Update internal code calling client Swatch middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CircleCI](https://circleci.com/gh/builtforme/swatchjs-koa.svg?style=svg)](https://circleci.com/gh/builtforme/swatchjs-koa) | [![codecov](https://codecov.io/gh/builtforme/swatchjs-koa/branch/master/graph/badge.svg)](https://codecov.io/gh/builtforme/swatchjs-koa) | [![Coverage Status](https://coveralls.io/repos/github/builtforme/swatchjs-koa/badge.svg?branch=master)](https://coveralls.io/github/builtforme/swatchjs-koa?branch=master) | [![Known Vulnerabilities](https://snyk.io/test/github/builtforme/swatchjs-koa/badge.svg)](https://snyk.io/test/github/builtforme/swatchjs-koa)
 
-An adapter to expose [swatchjs]() via [KOA](https://www.npmjs.com/package/koa).
+An adapter to expose [swatchjs](https://www.npmjs.com/package/swatchjs) via [KOA](https://www.npmjs.com/package/koa).
 
 ## Quick start
 
@@ -191,6 +191,14 @@ function sampleOnException(error) {
   throw error;
 }
 ```
+
+### Middleware
+
+The [swatchjs](https://www.npmjs.com/package/swatchjs) package allows the creation of middleware
+functions to be executed before the API handler. Those middleware functions should be written
+in the style of KOA middleware, accepting a Swatch context object and a callback function.
+The Swatch context has a `ctx.req` property which contains the request parameters copied from
+the [KOA](http://koajs.com/#context) `request` context.
 
 ## Developers
 

--- a/lib/context.js
+++ b/lib/context.js
@@ -3,8 +3,20 @@
 //   function that will init the swatch context and then await
 function init(options) {
   async function swatchCtxMiddleware(koaCtx, next) {
-    // Create the swatchCtx object on the KOA ctx
+    // Create the swatchCtx object from the KOA ctx
     koaCtx.swatchCtx = {};
+    koaCtx.swatchCtx.req = {
+      headers: Object.assign({}, koaCtx.headers),
+      href: koaCtx.request.href,
+      host: koaCtx.request.host,
+      method: koaCtx.request.method,
+      origin: koaCtx.request.origin,
+      path: koaCtx.request.path,
+      protocol: koaCtx.request.protocol,
+      query: koaCtx.request.query,
+      secure: koaCtx.request.secure,
+      url: koaCtx.request.url,
+    };
     koaCtx.swatchCtx.request = {
       onException: options.onException,
     };

--- a/lib/context.js
+++ b/lib/context.js
@@ -5,8 +5,12 @@ function init(options) {
   async function swatchCtxMiddleware(koaCtx, next) {
     // Create the swatchCtx object from the KOA ctx
     koaCtx.swatchCtx = {};
+
+    // Allow access to KOA ctx in case of emergency - Private
+    koaCtx.swatchCtx.koaCtx = () => (koaCtx);
+
     koaCtx.swatchCtx.req = {
-      headers: Object.assign({}, koaCtx.headers),
+      headers: Object.assign({}, koaCtx.request.headers),
       href: koaCtx.request.href,
       host: koaCtx.request.host,
       method: koaCtx.request.method,

--- a/lib/expose.js
+++ b/lib/expose.js
@@ -32,10 +32,10 @@ function expose(app, methods, opts) {
       const loggerM = [contextMiddleware, loggerMiddleware];
       const adapterM = loggerM.concat(adapterMiddleware);
       const validatorM = adapterM.concat(
-        [wrapper.wrap(validateMiddleware)],
+        [wrapper.wrapKoa(validateMiddleware)],
       );
       const methodM = validatorM.concat(
-        methodMiddleware.map(wrapper.wrap),
+        methodMiddleware.map(wrapper.wrapSwatch),
       );
       const allMiddleware = methodM.concat([methodHandler]);
 

--- a/lib/wrapper.js
+++ b/lib/wrapper.js
@@ -1,12 +1,12 @@
 const response = require('./response');
 
-// Generic function to wrap any `fn` as KOA middleware
-//  `fn` signature accepts KOA ctx + next callback
+// Generic function to wrap any `fn` as Swatch middleware
+//  `fn` signature accepts Swatch ctx + next callback
 //  Catches any errors and returns an error response
 function wrap(fn) {
   async function middlewareWrapper(koaCtx, next) {
     try {
-      await fn(koaCtx, next);
+      await fn(koaCtx.swatchCtx, next);
     } catch (error) {
       // Auth error should trigger failure response
       response.errorResponse(koaCtx, error);

--- a/lib/wrapper.js
+++ b/lib/wrapper.js
@@ -1,12 +1,14 @@
 const response = require('./response');
 
-// Generic function to wrap any `fn` as Swatch middleware
-//  `fn` signature accepts Swatch ctx + next callback
+// Generic function to wrap any `fn` as middleware
+//  `fn` signature accepts a ctx + next callback
+//  `ctxFn` maps from koaCtx to the expect `fn` ctx
 //  Catches any errors and returns an error response
-function wrap(fn) {
+function wrap(fn, ctxFn) {
   async function middlewareWrapper(koaCtx, next) {
     try {
-      await fn(koaCtx.swatchCtx, next);
+      const ctx = ctxFn(koaCtx);
+      await fn(ctx, next);
     } catch (error) {
       // Auth error should trigger failure response
       response.errorResponse(koaCtx, error);
@@ -16,7 +18,18 @@ function wrap(fn) {
   return middlewareWrapper;
 }
 
+// Wrap `fn` into middleware that accepts a KOA ctx
+function wrapKoa(fn) {
+  return wrap(fn, koaCtx => (koaCtx));
+}
+
+// Wrap `fn` into middleware that accepts a Swatch ctx
+function wrapSwatch(fn) {
+  return wrap(fn, koaCtx => (koaCtx.swatchCtx));
+}
+
 
 module.exports = {
-  wrap,
+  wrapKoa,
+  wrapSwatch,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "swatchjs-koa",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swatchjs-koa",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "description": "KOA adapter for swatchjs",
   "main": "dist/index.js",
   "scripts": {

--- a/test/context.test.js
+++ b/test/context.test.js
@@ -6,17 +6,44 @@ const expect = chai.expect;
 
 describe('context', () => {
   it('should initialize the swatchCtx', (done) => {
+    const exampleUrl = 'http://localhost:1234/some/path?name=test';
+
     const options = {
       onException: () => ('mapped_error'),
     };
     const fn = context.init(options);
 
-    const ctx = {};
-    fn(ctx, () => {
+    const ctx = {
+      request: {
+        href: exampleUrl,
+        host: 'localhost:1234',
+        headers: { authorization: 'value' },
+        method: 'GET',
+        origin: '',
+        path: 'some/path',
+        protocol: 'http',
+        query: '?name=test',
+        secure: false,
+        url: exampleUrl,
+      },
+    };
+    fn(ctx, () => {}).then(() => {
       const error = ctx.swatchCtx.request.onException('error');
       expect(error).to.equal('mapped_error');
 
+      expect(ctx.swatchCtx.req.href).to.equal(exampleUrl);
+      expect(ctx.swatchCtx.req.host).to.equal('localhost:1234');
+      expect(ctx.swatchCtx.req.method).to.equal('GET');
+      expect(ctx.swatchCtx.req.origin).to.equal('');
+      expect(ctx.swatchCtx.req.path).to.equal('some/path');
+      expect(ctx.swatchCtx.req.protocol).to.equal('http');
+      expect(ctx.swatchCtx.req.query).to.equal('?name=test');
+      expect(ctx.swatchCtx.req.secure).to.equal(false);
+      expect(ctx.swatchCtx.req.url).to.equal(exampleUrl);
+
+      expect(ctx.swatchCtx.req.headers.authorization).to.equal('value');
+
       done();
-    });
+    }).catch(done);
   });
 });

--- a/test/expose.test.js
+++ b/test/expose.test.js
@@ -93,10 +93,10 @@ describe('expose', () => {
         handler: () => (10),
         metadata: {
           middleware: [
-            (ctx) => {
-              ctx.body = {
-                id: ctx.swatchCtx.auth.id,
-                auth: ctx.swatchCtx.auth.auth,
+            (swatchCtx) => {
+              swatchCtx.koaCtx().body = {
+                id: swatchCtx.auth.id,
+                auth: swatchCtx.auth.auth,
               };
             },
           ],
@@ -134,9 +134,9 @@ describe('expose', () => {
         metadata: {
           noAuth: true,
           middleware: [
-            (ctx) => {
-              ctx.body = {
-                exists: Boolean(ctx.swatchCtx.auth),
+            (swatchCtx) => {
+              swatchCtx.koaCtx().body = {
+                exists: Boolean(swatchCtx.auth),
               };
             },
           ],
@@ -229,10 +229,10 @@ describe('expose', () => {
         handler: () => (10),
         metadata: {
           middleware: [
-            (ctx) => {
-              ctx.body = {
-                id: ctx.swatchCtx.auth.id,
-                auth: ctx.swatchCtx.auth.auth,
+            (swatchCtx) => {
+              swatchCtx.koaCtx().body = {
+                id: swatchCtx.auth.id,
+                auth: swatchCtx.auth.auth,
               };
             },
           ],
@@ -347,10 +347,10 @@ describe('expose', () => {
         handler: () => (10),
         metadata: {
           middleware: [
-            (ctx) => {
-              ctx.body = {
-                id: ctx.swatchCtx.auth.id,
-                auth: ctx.swatchCtx.auth.auth,
+            (swatchCtx) => {
+              swatchCtx.koaCtx().body = {
+                id: swatchCtx.auth.id,
+                auth: swatchCtx.auth.auth,
               };
             },
           ],
@@ -450,35 +450,6 @@ describe('expose', () => {
       });
   });
 
-  it('should allow sync middleware before running sync handler', (done) => {
-    const app = initApp();
-    const model = swatch({
-      add: {
-        handler: () => (500),
-        metadata: {
-          middleware: [
-            (ctx, next) => {
-              ctx.swatchCtx.value = 2000;
-              next();
-            },
-          ],
-        },
-      },
-    });
-
-    expose(app, model);
-
-    request(http.createServer(app.callback()))
-      .get('/add')
-      .expect(200)
-      .end((err, res) => {
-        expect(err).to.equal(null);
-        expect(res.body.ok).to.equal(true);
-        expect(res.body.result).to.equal(500);
-        done();
-      });
-  });
-
   it('should allow sync middleware before running async handler', (done) => {
     const app = initApp();
     const model = swatch({
@@ -492,8 +463,8 @@ describe('expose', () => {
         ),
         metadata: {
           middleware: [
-            async (ctx, next) => {
-              ctx.swatchCtx.value = 3000;
+            async (swatchCtx, next) => {
+              swatchCtx.value = 3000;
               await next();
             },
           ],
@@ -521,9 +492,9 @@ describe('expose', () => {
         handler: () => (1000),
         metadata: {
           middleware: [
-            async (ctx, next) => {
+            async (swatchCtx, next) => {
               const result = await Promise.resolve(2000);
-              ctx.swatchCtx.value = result;
+              swatchCtx.value = result;
 
               await next();
             },
@@ -558,9 +529,9 @@ describe('expose', () => {
         ),
         metadata: {
           middleware: [
-            async (ctx, next) => {
+            async (swatchCtx, next) => {
               const result = await Promise.resolve(3000);
-              ctx.swatchCtx.value = result;
+              swatchCtx.value = result;
 
               await next();
             },


### PR DESCRIPTION
Two changes here. First of all, when we initialize the swatchCtx at the start of a request (aka the first thing that happens in the underlying KOA request cycle), copy the important request parameters out of the koa ctx and into the swatch ctx. In general, clients should not need to rely on these parameters, but some of them are useful, like the headers used to make certain decisions.

Secondly, when we trigger a client middleware function, we previous passed the koaCtx, but that seems to lose some of the abstraction, so we should instead pass the swatchCtx, so that any client writing handlers for swatch can rely directly on a swatch interface. The other reason this is important is because when we support batch endpoints, the underlying behavior is to call each of the request ops with its own individual context. This is possible to do with a clean swatch context, but I dont want to get into the business of trying to generate a clean koa ctx, plus the original koa request is typically to the 'batch' endpoint with a block of params, not the individual handler we are trying to execute on each iteration