### PR TITLE
Add support for returning a unique request context ID in header

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,13 +123,14 @@ example above) which takes the following parameters:
 
 The `options` object has the following properties:
 
-| Property     | Example   | Default value     | Description   |
-|:---          |:---       |:---               |:---           |
-|`verbs`       |`['get']`  |`['get','post']`   | An array with a list of enabled HTTP verbs. Each verb must be a string. |
-|`prefix`      |`'api'`    |`''`               | A URL prefix to be added to every route. For example, if the value of this option is `'product'`, then the URL of all APIs will start with `/product/`.   |
-|`authAdapter` |`fn`       |See below          | A function to perform authentication and extract credentials from a request. |
-|`onException` |`fn`       |See below          | A function to catch any exception and optionally rescue before returning an error. |
-|`rawResponse` |`boolean`  |`false`            | Returns the raw response object without the `{ ok: true }` or `{ ok: false }` wrapper. |
+| Property         | Example   | Default value     | Description   |
+|:---              |:---       |:---               |:---           |
+|`verbs`           |`['get']`  |`['get','post']`   | An array with a list of enabled HTTP verbs. Each verb must be a string. |
+|`prefix`          |`'api'`    |`''`               | A URL prefix to be added to every route. For example, if the value of this option is `'product'`, then the URL of all APIs will start with `/product/`.   |
+|`authAdapter`     |`fn`       |See below          | A function to perform authentication and extract credentials from a request. |
+|`onException`     |`fn`       |See below          | A function to catch any exception and optionally rescue before returning an error. |
+|`rawResponse`     |`boolean`  |`false`            | Returns the raw response object without the `{ ok: true }` or `{ ok: false }` wrapper. |
+|`loggerRequestIdKey` |`string`   |`undefined`     | A string matching the koa-bunyan-logger key for `requestIdContext`.`prop` parameter. If present, the request ID will be returned in `x-swatch-request-id` response header. If empty, no header will be set. |
 
 ### The `authAdapter` function
 
@@ -191,6 +192,21 @@ function sampleOnException(error) {
   throw error;
 }
 ```
+
+### The `loggerRequestIdKey` parameter
+
+Clients can use the [koa-bunyan-logger](https://www.npmjs.com/package/koa-bunyan-logger) package
+to configure a request logger for their service. That package exposes a `requestIdContext` function
+that will generate a unique ID for each request to be included in the output logs. The unique ID is
+saved on the KOA context object under a key you can specify with the `prop` parameter, with a
+default value of `reqId`. See that package documentation for details.
+
+Currently, `swatchjs-koa` supports this request logger as a part of the `swatchCtx`. To provide
+additional debugging support, users can have the unique request ID included as a response header
+named `x-swatchjs-request-id`. To enable this header, set the `loggerRequestId` property in the
+`swatchjs-koa` configuration to a string that matches the `prop` parameter passed into the
+`koa-bunyan-logger` configuration. This will allow `swatchjs-koa` to find the request ID parameter
+from the KOA context. If not set, the header will not be included in the response.
 
 ### Middleware
 

--- a/README.md
+++ b/README.md
@@ -123,14 +123,14 @@ example above) which takes the following parameters:
 
 The `options` object has the following properties:
 
-| Property         | Example   | Default value     | Description   |
-|:---              |:---       |:---               |:---           |
-|`verbs`           |`['get']`  |`['get','post']`   | An array with a list of enabled HTTP verbs. Each verb must be a string. |
-|`prefix`          |`'api'`    |`''`               | A URL prefix to be added to every route. For example, if the value of this option is `'product'`, then the URL of all APIs will start with `/product/`.   |
-|`authAdapter`     |`fn`       |See below          | A function to perform authentication and extract credentials from a request. |
-|`onException`     |`fn`       |See below          | A function to catch any exception and optionally rescue before returning an error. |
-|`rawResponse`     |`boolean`  |`false`            | Returns the raw response object without the `{ ok: true }` or `{ ok: false }` wrapper. |
-|`loggerRequestIdKey` |`string`   |`undefined`     | A string matching the koa-bunyan-logger key for `requestIdContext`.`prop` parameter. If present, the request ID will be returned in `x-swatch-request-id` response header. If empty, no header will be set. |
+| Property     | Example   | Default value     | Description   |
+|:---          |:---       |:---               |:---           |
+|`verbs`       |`['get']`  |`['get','post']`   | An array with a list of enabled HTTP verbs. Each verb must be a string. |
+|`prefix`      |`'api'`    |`''`               | A URL prefix to be added to every route. For example, if the value of this option is `'product'`, then the URL of all APIs will start with `/product/`.   |
+|`authAdapter` |`fn`       |See below          | A function to perform authentication and extract credentials from a request. |
+|`onException` |`fn`       |See below          | A function to catch any exception and optionally rescue before returning an error. |
+|`rawResponse` |`boolean`  |`false`            | Returns the raw response object without the `{ ok: true }` or `{ ok: false }` wrapper. |
+|`requestIdProp`|`string`  |`undefined`        | A string matching the koa-bunyan-logger key for `requestIdContext`.`prop` parameter. If present, the request ID will be returned in `x-swatch-request-id` response header. If empty, no header will be set. |
 
 ### The `authAdapter` function
 
@@ -193,7 +193,7 @@ function sampleOnException(error) {
 }
 ```
 
-### The `loggerRequestIdKey` parameter
+### The `requestIdProp` parameter
 
 Clients can use the [koa-bunyan-logger](https://www.npmjs.com/package/koa-bunyan-logger) package
 to configure a request logger for their service. That package exposes a `requestIdContext` function

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -26,7 +26,9 @@ function defaultPrefix(prefix) {
   return (prefix && `/${prefix}/`) || '/';
 }
 
-function defaultAuthAdapter(authAdapter) {
+function defaultAuthAdapter(options) {
+  const authAdapter = options && options.authAdapter;
+
   if (authAdapter !== undefined) {
     if (!(typeof authAdapter === 'function')) {
       throw TypeError('function required for authAdapter');
@@ -48,7 +50,7 @@ function defaultAuthAdapter(authAdapter) {
       await next();
     } catch (error) {
       // Auth error should trigger failure response
-      response.errorResponse(koaCtx, error);
+      response.errorResponse(options)(koaCtx, error);
     }
   }
 
@@ -77,13 +79,27 @@ function defaultRawResponse(rawResponse) {
   return Boolean(rawResponse);
 }
 
+function defaultLoggerRequestIdKey(loggerRequestIdKey) {
+  if (loggerRequestIdKey === undefined || loggerRequestIdKey === null) {
+    return undefined;
+  }
+  if (typeof loggerRequestIdKey !== 'string') {
+    return undefined;
+  }
+  if (loggerRequestIdKey === '') {
+    return undefined;
+  }
+  return loggerRequestIdKey;
+}
+
 function defaults(options) {
   return {
+    authAdapter: defaultAuthAdapter(options),
     verbs: defaultVerbs(options && options.verbs),
     prefix: defaultPrefix(options && options.prefix),
-    authAdapter: defaultAuthAdapter(options && options.authAdapter),
     onException: defaultOnException(options && options.onException),
     rawResponse: defaultRawResponse(options && options.rawResponse),
+    loggerRequestIdKey: defaultLoggerRequestIdKey(options && options.loggerRequestIdKey),
   };
 }
 

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -79,17 +79,17 @@ function defaultRawResponse(rawResponse) {
   return Boolean(rawResponse);
 }
 
-function defaultLoggerRequestIdKey(loggerRequestIdKey) {
-  if (loggerRequestIdKey === undefined || loggerRequestIdKey === null) {
+function defaultRequestIdProp(requestIdProp) {
+  if (requestIdProp === undefined || requestIdProp === null) {
     return undefined;
   }
-  if (typeof loggerRequestIdKey !== 'string') {
+  if (typeof requestIdProp !== 'string') {
     return undefined;
   }
-  if (loggerRequestIdKey === '') {
+  if (requestIdProp === '') {
     return undefined;
   }
-  return loggerRequestIdKey;
+  return requestIdProp;
 }
 
 function defaults(options) {
@@ -99,7 +99,7 @@ function defaults(options) {
     prefix: defaultPrefix(options && options.prefix),
     onException: defaultOnException(options && options.onException),
     rawResponse: defaultRawResponse(options && options.rawResponse),
-    loggerRequestIdKey: defaultLoggerRequestIdKey(options && options.loggerRequestIdKey),
+    requestIdProp: defaultRequestIdProp(options && options.requestIdProp),
   };
 }
 

--- a/lib/expose.js
+++ b/lib/expose.js
@@ -20,8 +20,8 @@ function expose(app, methods, opts) {
 
       const noAuth = method.metadata.noAuth;
       const methodHandler = options.rawResponse ?
-        handler.raw(method.handle) :
-        handler.wrapped(method.handle);
+        handler.raw(method.handle, options) :
+        handler.wrapped(method.handle, options);
 
       const contextMiddleware = context.init(options);
       const loggerMiddleware = middleware.logger.init;
@@ -32,10 +32,12 @@ function expose(app, methods, opts) {
       const loggerM = [contextMiddleware, loggerMiddleware];
       const adapterM = loggerM.concat(adapterMiddleware);
       const validatorM = adapterM.concat(
-        [wrapper.wrapKoa(validateMiddleware)],
+        [wrapper.wrapKoa(validateMiddleware, options)],
       );
       const methodM = validatorM.concat(
-        methodMiddleware.map(wrapper.wrapSwatch),
+        methodMiddleware.map(m => (
+          wrapper.wrapSwatch(m, options)
+        )),
       );
       const allMiddleware = methodM.concat([methodHandler]);
 

--- a/lib/handler/index.js
+++ b/lib/handler/index.js
@@ -5,32 +5,32 @@ const response = require('../response');
 //  to execute the request and either return the expected success
 //  response or an error response, which will vary based on whether
 //  the endpoint returns a raw result or a wrapped Swatch result
-function handler(requestHandler, successResponse, errorResponse) {
+function handler(requestHandler, successHandler, errorHandler) {
   async function handleRequest(koaCtx) {
     try {
       const result = await requestHandler(koaCtx);
-      successResponse(koaCtx, result);
+      successHandler(koaCtx, result);
     } catch (error) {
-      errorResponse(koaCtx, error);
+      errorHandler(koaCtx, error);
     }
   }
 
   return handleRequest;
 }
 
-function raw(requestHandler) {
+function raw(requestHandler, options) {
   return handler(
     requestHandler,
-    response.rawResponse,
-    response.rawResponse,
+    response.rawResponse(options),
+    response.rawResponse(options),
   );
 }
 
-function wrapped(requestHandler) {
+function wrapped(requestHandler, options) {
   return handler(
     requestHandler,
-    response.successResponse,
-    response.errorResponse,
+    response.successResponse(options),
+    response.errorResponse(options),
   );
 }
 

--- a/lib/response.js
+++ b/lib/response.js
@@ -7,9 +7,9 @@ const REQUEST_ID_HEADER_NAME = 'x-swatch-request-id';
 function responseHandler(fn, options) {
   function setResponse(ctx, result) {
     // Decide whether to set the request id as response header
-    if (options.loggerRequestIdKey !== undefined) {
-      const key = options.loggerRequestIdKey;
-      const correlationId = ctx[key];
+    const prop = options.requestIdProp;
+    if (prop !== undefined) {
+      const correlationId = ctx[prop];
       if (correlationId !== undefined) {
         ctx.set(REQUEST_ID_HEADER_NAME, correlationId);
       }

--- a/lib/response.js
+++ b/lib/response.js
@@ -2,25 +2,44 @@ const middleware = require('swatchjs-koa-middleware');
 
 const response = middleware.response;
 
+const REQUEST_ID_HEADER_NAME = 'x-swatch-request-id';
+
+function responseHandler(fn, options) {
+  function setResponse(ctx, result) {
+    // Decide whether to set the request id as response header
+    if (options.loggerRequestIdKey !== undefined) {
+      const key = options.loggerRequestIdKey;
+      const correlationId = ctx[key];
+      if (correlationId !== undefined) {
+        ctx.set(REQUEST_ID_HEADER_NAME, correlationId);
+      }
+    }
+
+    // Process the request result and set response body
+    ctx.body = fn.call(ctx.swatchCtx, result);
+  }
+  return setResponse;
+}
+
 // Helper methods to set a response with no Swatch metadata
 //  `ctx` is a Koa context that will handle responding
 //  `result` can be any object or primitive type
-function rawResponse(ctx, result) {
-  ctx.body = response.raw.call(ctx.swatchCtx, result);
+function rawResponse(options) {
+  return responseHandler(response.raw, options);
 }
 
 // Helper methods to set a success or error response
 //  `ctx` is a Koa context that will handle responding
 //  `result` can be any object or primitive type
-function successResponse(ctx, result) {
-  ctx.body = response.success.call(ctx.swatchCtx, result);
+function successResponse(options) {
+  return responseHandler(response.success, options);
 }
 
 // Helper methods to set a success or error response
 //  `ctx` is a Koa context that will handle responding
 //  `errorObj'` can be a string, Error object, or dict
-function errorResponse(ctx, errorObj) {
-  ctx.body = response.error.call(ctx.swatchCtx, errorObj);
+function errorResponse(options) {
+  return responseHandler(response.error, options);
 }
 
 module.exports = {

--- a/lib/wrapper.js
+++ b/lib/wrapper.js
@@ -4,14 +4,14 @@ const response = require('./response');
 //  `fn` signature accepts a ctx + next callback
 //  `ctxFn` maps from koaCtx to the expect `fn` ctx
 //  Catches any errors and returns an error response
-function wrap(fn, ctxFn) {
+function wrap(fn, options, ctxFn) {
   async function middlewareWrapper(koaCtx, next) {
     try {
       const ctx = ctxFn(koaCtx);
       await fn(ctx, next);
     } catch (error) {
       // Auth error should trigger failure response
-      response.errorResponse(koaCtx, error);
+      response.errorResponse(options)(koaCtx, error);
     }
   }
 
@@ -19,13 +19,13 @@ function wrap(fn, ctxFn) {
 }
 
 // Wrap `fn` into middleware that accepts a KOA ctx
-function wrapKoa(fn) {
-  return wrap(fn, koaCtx => (koaCtx));
+function wrapKoa(fn, options) {
+  return wrap(fn, options, koaCtx => (koaCtx));
 }
 
 // Wrap `fn` into middleware that accepts a Swatch ctx
-function wrapSwatch(fn) {
-  return wrap(fn, koaCtx => (koaCtx.swatchCtx));
+function wrapSwatch(fn, options) {
+  return wrap(fn, options, koaCtx => (koaCtx.swatchCtx));
 }
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "swatchjs-koa",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -854,7 +854,7 @@
         "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
         "babel-plugin-transform-exponentiation-operator": "6.24.1",
         "babel-plugin-transform-regenerator": "6.26.0",
-        "browserslist": "2.6.1",
+        "browserslist": "2.8.0",
         "invariant": "2.2.2",
         "semver": "5.4.1"
       }
@@ -1147,12 +1147,12 @@
       "dev": true
     },
     "browserslist": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.6.1.tgz",
-      "integrity": "sha512-HBZwVT7ciQB9KlXM3AUMQbnQXtHWPsEUKQTiS0BEFfY5bOrMl94ORaqQD1GyuTGh69ZmYeue9QBqiw219e09eQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.8.0.tgz",
+      "integrity": "sha512-iiWHM1Et6Q4TQpB7Ar6pxuM3TNMXasVJY4Y/oh3q38EwR3Z+IdZ9MyVf7PI4MJFB4xpwMcZgs9bEUnPG2E3TCA==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "1.0.30000756",
+        "caniuse-lite": "1.0.30000760",
         "electron-to-chromium": "1.3.27"
       }
     },
@@ -1207,9 +1207,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30000756",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000756.tgz",
-      "integrity": "sha1-PacBwVIbn6uHAExt58l/pH2+qtI=",
+      "version": "1.0.30000760",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000760.tgz",
+      "integrity": "sha1-7HIDlXQvHH7IlH/W3SYE53qPmP8=",
       "dev": true
     },
     "caseless": {
@@ -1229,7 +1229,7 @@
         "deep-eql": "3.0.1",
         "get-func-name": "2.0.0",
         "pathval": "1.1.0",
-        "type-detect": "4.0.3"
+        "type-detect": "4.0.5"
       }
     },
     "chai-as-promised": {
@@ -1317,9 +1317,9 @@
       }
     },
     "color-convert": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
-      "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "dev": true,
       "requires": {
         "color-name": "1.1.3"
@@ -1543,7 +1543,7 @@
       "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
       "requires": {
-        "type-detect": "4.0.3"
+        "type-detect": "4.0.5"
       }
     },
     "deep-equal": {
@@ -1744,7 +1744,7 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -3408,7 +3408,7 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -3846,9 +3846,9 @@
       }
     },
     "koa": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/koa/-/koa-2.3.0.tgz",
-      "integrity": "sha1-nh6OTaQBg5xXuFJ+rcV/dhJ1Vac=",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/koa/-/koa-2.4.1.tgz",
+      "integrity": "sha512-3caQ9OyLDYSL3wAhVfv2s9k3tLNgW18QxnKIPaRjzG9uXyDhp4tOo+U+XtbY+xbzEiCW5smjxMCegpZqCjmjMw==",
       "dev": true,
       "requires": {
         "accepts": "1.3.4",
@@ -4115,9 +4115,9 @@
       "dev": true
     },
     "lolex": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.1.3.tgz",
-      "integrity": "sha512-BdHq78SeI+6PAUtl4atDuCt7L6E4fab3mSRtqxm4ywaXe4uP7jZ0TTcFNuU20syUjxZc2l7jFqKVMJ+AX0LnpQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.0.tgz",
+      "integrity": "sha512-rPO6R1t8PjYL6xbsFUg7aByKkWAql907na6powPBORVs4DCm8aMBUkL4+6CXO0gEIV8vtu3mWV0FB8ZaCYPBmA==",
       "dev": true
     },
     "loose-envify": {
@@ -4432,9 +4432,9 @@
       "dev": true
     },
     "nyc": {
-      "version": "11.2.1",
-      "resolved": "https://registry.npmjs.org/nyc/-/nyc-11.2.1.tgz",
-      "integrity": "sha1-rYUK/p261/SXByi0suR/7Rw4chw=",
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-11.3.0.tgz",
+      "integrity": "sha512-oUu0WHt1k/JMIODvAYXX6C50Mupw2GO34P/Jdg2ty9xrLufBthHiKR2gf08aF+9S0abW1fl24R7iKRBXzibZmg==",
       "dev": true,
       "requires": {
         "archy": "1.0.0",
@@ -4448,22 +4448,22 @@
         "foreground-child": "1.5.6",
         "glob": "7.1.2",
         "istanbul-lib-coverage": "1.1.1",
-        "istanbul-lib-hook": "1.0.7",
-        "istanbul-lib-instrument": "1.8.0",
-        "istanbul-lib-report": "1.1.1",
-        "istanbul-lib-source-maps": "1.2.1",
-        "istanbul-reports": "1.1.2",
+        "istanbul-lib-hook": "1.1.0",
+        "istanbul-lib-instrument": "1.9.1",
+        "istanbul-lib-report": "1.1.2",
+        "istanbul-lib-source-maps": "1.2.2",
+        "istanbul-reports": "1.1.3",
         "md5-hex": "1.3.0",
         "merge-source-map": "1.0.4",
         "micromatch": "2.3.11",
         "mkdirp": "0.5.1",
         "resolve-from": "2.0.0",
-        "rimraf": "2.6.1",
+        "rimraf": "2.6.2",
         "signal-exit": "3.0.2",
         "spawn-wrap": "1.3.8",
         "test-exclude": "4.1.1",
-        "yargs": "8.0.2",
-        "yargs-parser": "5.0.0"
+        "yargs": "10.0.3",
+        "yargs-parser": "8.0.0"
       },
       "dependencies": {
         "align-text": {
@@ -4596,7 +4596,7 @@
             "babel-runtime": "6.26.0",
             "babel-types": "6.26.0",
             "babylon": "6.18.0",
-            "debug": "2.6.8",
+            "debug": "2.6.9",
             "globals": "9.18.0",
             "invariant": "2.2.2",
             "lodash": "4.17.4"
@@ -4739,7 +4739,7 @@
           }
         },
         "debug": {
-          "version": "2.6.8",
+          "version": "2.6.9",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -4953,7 +4953,7 @@
           "dev": true
         },
         "handlebars": {
-          "version": "4.0.10",
+          "version": "4.0.11",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -5140,7 +5140,7 @@
           "dev": true
         },
         "istanbul-lib-hook": {
-          "version": "1.0.7",
+          "version": "1.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -5148,7 +5148,7 @@
           }
         },
         "istanbul-lib-instrument": {
-          "version": "1.8.0",
+          "version": "1.9.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -5162,7 +5162,7 @@
           }
         },
         "istanbul-lib-report": {
-          "version": "1.1.1",
+          "version": "1.1.2",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -5183,23 +5183,33 @@
           }
         },
         "istanbul-lib-source-maps": {
-          "version": "1.2.1",
+          "version": "1.2.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "debug": "2.6.8",
+            "debug": "3.1.0",
             "istanbul-lib-coverage": "1.1.1",
             "mkdirp": "0.5.1",
-            "rimraf": "2.6.1",
+            "rimraf": "2.6.2",
             "source-map": "0.5.7"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "3.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
           }
         },
         "istanbul-reports": {
-          "version": "1.1.2",
+          "version": "1.1.3",
           "bundled": true,
           "dev": true,
           "requires": {
-            "handlebars": "4.0.10"
+            "handlebars": "4.0.11"
           }
         },
         "js-tokens": {
@@ -5692,7 +5702,7 @@
           }
         },
         "rimraf": {
-          "version": "2.6.1",
+          "version": "2.6.2",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -5745,7 +5755,7 @@
             "foreground-child": "1.5.6",
             "mkdirp": "0.5.1",
             "os-homedir": "1.0.2",
-            "rimraf": "2.6.1",
+            "rimraf": "2.6.2",
             "signal-exit": "3.0.2",
             "which": "1.3.0"
           }
@@ -5956,30 +5966,24 @@
           "dev": true
         },
         "yargs": {
-          "version": "8.0.2",
+          "version": "10.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
-            "camelcase": "4.1.0",
             "cliui": "3.2.0",
             "decamelize": "1.2.0",
+            "find-up": "2.1.0",
             "get-caller-file": "1.0.2",
             "os-locale": "2.1.0",
-            "read-pkg-up": "2.0.0",
             "require-directory": "2.1.1",
             "require-main-filename": "1.0.1",
             "set-blocking": "2.0.0",
             "string-width": "2.1.1",
             "which-module": "2.0.0",
             "y18n": "3.2.1",
-            "yargs-parser": "7.0.0"
+            "yargs-parser": "8.0.0"
           },
           "dependencies": {
-            "camelcase": {
-              "version": "4.1.0",
-              "bundled": true,
-              "dev": true
-            },
             "cliui": {
               "version": "3.2.0",
               "bundled": true,
@@ -6001,70 +6005,19 @@
                   }
                 }
               }
-            },
-            "load-json-file": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "graceful-fs": "4.1.11",
-                "parse-json": "2.2.0",
-                "pify": "2.3.0",
-                "strip-bom": "3.0.0"
-              }
-            },
-            "path-type": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "pify": "2.3.0"
-              }
-            },
-            "read-pkg": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "load-json-file": "2.0.0",
-                "normalize-package-data": "2.4.0",
-                "path-type": "2.0.0"
-              }
-            },
-            "read-pkg-up": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "find-up": "2.1.0",
-                "read-pkg": "2.0.0"
-              }
-            },
-            "strip-bom": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "yargs-parser": {
-              "version": "7.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "camelcase": "4.1.0"
-              }
             }
           }
         },
         "yargs-parser": {
-          "version": "5.0.0",
+          "version": "8.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "camelcase": "3.0.0"
+            "camelcase": "4.1.0"
           },
           "dependencies": {
             "camelcase": {
-              "version": "3.0.0",
+              "version": "4.1.0",
               "bundled": true,
               "dev": true
             }
@@ -6728,13 +6681,13 @@
         "diff": "3.2.0",
         "formatio": "1.2.0",
         "lodash.get": "4.4.2",
-        "lolex": "2.1.3",
+        "lolex": "2.3.0",
         "native-promise-only": "0.8.1",
         "nise": "1.2.0",
         "path-to-regexp": "1.7.0",
         "samsam": "1.3.0",
         "text-encoding": "0.6.4",
-        "type-detect": "4.0.3"
+        "type-detect": "4.0.5"
       }
     },
     "slash": {
@@ -6910,9 +6863,9 @@
       "dev": true
     },
     "superagent": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.0.tgz",
-      "integrity": "sha512-71XGWgtn70TNwgmgYa69dPOYg55aU9FCahjUNY03rOrKvaTCaU3b9MeZmqonmf9Od96SCxr3vGfEAnhM7dtxCw==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.1.tgz",
+      "integrity": "sha512-VMBFLYgFuRdfeNQSMLbxGSLfmXL/xc+OO+BZp41Za/NRDBet/BNbkRJrYzCUu0u4GU0i/ml2dtT8b9qgkw9z6Q==",
       "dev": true,
       "requires": {
         "component-emitter": "1.2.1",
@@ -6962,7 +6915,7 @@
       "dev": true,
       "requires": {
         "methods": "1.1.2",
-        "superagent": "3.8.0"
+        "superagent": "3.8.1"
       }
     },
     "supports-color": {
@@ -7010,7 +6963,7 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -7138,9 +7091,9 @@
       }
     },
     "type-detect": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.3.tgz",
-      "integrity": "sha1-Dj8mcLRAmbC0bChNE2p+9Jx0wuo=",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.5.tgz",
+      "integrity": "sha512-N9IvkQslUGYGC24RkJk1ba99foK6TkwC2FHAEBlQFBP0RxQZS8ZpJuAZcwiY/w9ZJHFQb1aOXBI60OdxhTrwEQ==",
       "dev": true
     },
     "type-is": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swatchjs-koa",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "KOA adapter for swatchjs",
   "main": "dist/index.js",
   "scripts": {

--- a/test/defaults.test.js
+++ b/test/defaults.test.js
@@ -7,7 +7,7 @@ describe('defaults', () => {
       const options = defaults();
       expect(options).to.be.an('object').that.has.all.keys(
         'verbs', 'prefix', 'authAdapter', 'onException',
-        'rawResponse', 'loggerRequestIdKey',
+        'rawResponse', 'requestIdProp',
       );
     });
   });
@@ -112,7 +112,7 @@ describe('defaults', () => {
       }
       const options = {
         authAdapter,
-        loggerRequestIdKey: 'whoops',
+        requestIdProp: 'whoops',
       };
 
       let reqId = '';
@@ -138,7 +138,7 @@ describe('defaults', () => {
       }
       const options = {
         authAdapter,
-        loggerRequestIdKey: 'reqId',
+        requestIdProp: 'reqId',
       };
 
       let reqId = '';
@@ -217,37 +217,37 @@ describe('defaults', () => {
     });
   });
 
-  describe('loggerRequestIdKey', () => {
-    it('should use the passed loggerRequestIdKey value', () => {
+  describe('requestIdProp', () => {
+    it('should use the passed requestIdProp value', () => {
       const options = {
-        loggerRequestIdKey: 'correlationId',
+        requestIdProp: 'correlationId',
       };
-      expect(defaults(options).loggerRequestIdKey).to.equal('correlationId');
+      expect(defaults(options).requestIdProp).to.equal('correlationId');
     });
 
     it('should ignore an empty string', () => {
       const options = {
-        loggerRequestIdKey: '',
+        requestIdProp: '',
       };
-      expect(defaults(options).loggerRequestIdKey).to.equal(undefined);
+      expect(defaults(options).requestIdProp).to.equal(undefined);
     });
 
     it('should ignore a null input', () => {
       const options = {
-        loggerRequestIdKey: null,
+        requestIdProp: null,
       };
-      expect(defaults(options).loggerRequestIdKey).to.equal(undefined);
+      expect(defaults(options).requestIdProp).to.equal(undefined);
     });
 
     it('should ignore a non-string input', () => {
       const options = {
-        loggerRequestIdKey: 10,
+        requestIdProp: 10,
       };
-      expect(defaults(options).loggerRequestIdKey).to.equal(undefined);
+      expect(defaults(options).requestIdProp).to.equal(undefined);
     });
 
     it('should default to undefined if not specified', () => {
-      expect(defaults({}).loggerRequestIdKey).to.equal(undefined);
+      expect(defaults({}).requestIdProp).to.equal(undefined);
     });
   });
 });

--- a/test/response.test.js
+++ b/test/response.test.js
@@ -10,9 +10,14 @@ const logger = bunyan.createLogger({
   streams: [{ path: '/dev/null' }],
 });
 
+const emptyOptions = {};
+const successHandlerFn = response.successResponse(emptyOptions);
+const errorHandlerFn = response.errorResponse(emptyOptions);
+
 function initCtx(onException) {
   return {
     body: {},
+    set: () => {},
     swatchCtx: {
       logger,
       request: {
@@ -23,14 +28,14 @@ function initCtx(onException) {
 }
 
 describe('response', () => {
-  it('should handle success responses', () => {
+  it('should handle success responses without request ID', () => {
     const ctx = initCtx(() => {});
     const result = {
       name: 'test',
       value: 'value',
     };
 
-    response.successResponse(ctx, result);
+    successHandlerFn(ctx, result);
 
     expect(ctx.body).to.deep.equal({
       ok: true,
@@ -42,7 +47,7 @@ describe('response', () => {
     const error = 'error_code';
     const ctx = initCtx((arg) => { throw arg; });
 
-    response.errorResponse(ctx, error);
+    errorHandlerFn(ctx, error);
 
     expect(ctx.body).to.deep.equal({
       ok: false,
@@ -57,7 +62,7 @@ describe('response', () => {
     const ctx = initCtx((arg) => { throw arg; });
     const errorObj = new Error(error);
 
-    response.errorResponse(ctx, errorObj);
+    errorHandlerFn(ctx, errorObj);
 
     expect(ctx.body).to.deep.equal({
       ok: false,
@@ -76,7 +81,7 @@ describe('response', () => {
       details,
     };
 
-    response.errorResponse(ctx, errorObj);
+    errorHandlerFn(ctx, errorObj);
 
     expect(ctx.body).to.deep.equal({
       ok: false,
@@ -97,7 +102,7 @@ describe('response', () => {
       details,
     };
 
-    response.errorResponse(ctx, errorObj);
+    errorHandlerFn(ctx, errorObj);
 
     expect(ctx.body).to.deep.equal({
       ok: false,
@@ -115,7 +120,7 @@ describe('response', () => {
     };
     const ctx = initCtx(() => ('its_actually_fine'));
 
-    response.errorResponse(ctx, errorObj);
+    errorHandlerFn(ctx, errorObj);
 
     expect(ctx.body).to.deep.equal({
       ok: true,


### PR DESCRIPTION
Currently, swatchjs-koa supports the koa-bunyan-logger as a request logger that generates a unique requestId to be used in log messages throughout the request. This PR adds a new property to the swatchjs-koa configuration options, which allows the client to pass in the property name (which they also configure when setting up the koa-bunyan-logger), which if present, will be grabbed from the ctx and returned as a response header to the caller. This will let people opt in to having their requests return the requestId so they can easily find it and use it to search logs