### PR TITLE
Bump uglify-js dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1168,7 +1168,6 @@
         "moo-server": "1.3.0",
         "promised-io": "0.3.5",
         "timespan": "2.3.0",
-        "uglify-js": "1.3.5",
         "walker": "1.0.7",
         "winston": "2.4.0",
         "wrench": "1.3.9"
@@ -7113,10 +7112,25 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.3.5.tgz",
-      "integrity": "sha1-S1v/+Rhu/7qoiOTJ6UvZ/EyUkp0=",
-      "dev": true
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.12.tgz",
+      "integrity": "sha512-4jxrTXlV0HaXTsNILfXW0eey7Qo8qHYM6ih5ZNh45erDWU2GHmKDmekwBTskDb12h+kdd2DBvdzqVb47YzNmTA==",
+      "requires": {
+        "commander": "2.14.1",
+        "source-map": "0.6.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.14.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
+          "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw=="
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
+      }
     },
     "urlgrey": {
       "version": "0.4.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "swatchjs-koa",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,15 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@sinonjs/formatio": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+      "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
+      "dev": true,
+      "requires": {
+        "samsam": "1.3.0"
+      }
+    },
     "accepts": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
@@ -165,12 +174,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
       "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
-      "dev": true
-    },
-    "async": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
-      "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=",
       "dev": true
     },
     "async-each": {
@@ -1156,23 +1159,6 @@
         "electron-to-chromium": "1.3.27"
       }
     },
-    "build": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/build/-/build-0.1.4.tgz",
-      "integrity": "sha1-cH/gJv/O3crL/c3zVur9pk8VEEY=",
-      "dev": true,
-      "requires": {
-        "cssmin": "0.3.2",
-        "jsmin": "1.0.1",
-        "jxLoader": "0.1.1",
-        "moo-server": "1.3.0",
-        "promised-io": "0.3.5",
-        "timespan": "2.3.0",
-        "walker": "1.0.7",
-        "winston": "2.4.0",
-        "wrench": "1.3.9"
-      }
-    },
     "builtin-modules": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
@@ -1328,12 +1314,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
-    },
-    "colors": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
       "dev": true
     },
     "combined-stream": {
@@ -1498,18 +1478,6 @@
       "requires": {
         "boom": "2.10.1"
       }
-    },
-    "cssmin": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/cssmin/-/cssmin-0.3.2.tgz",
-      "integrity": "sha1-3c5MVHtRCuDVlKjx+/iq+OLFwA0=",
-      "dev": true
-    },
-    "cycle": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
-      "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI=",
-      "dev": true
     },
     "dashdash": {
       "version": "1.14.1",
@@ -2007,12 +1975,6 @@
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
     },
-    "eyes": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
-      "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=",
-      "dev": true
-    },
     "fast-deep-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
@@ -2125,15 +2087,6 @@
         "asynckit": "0.4.0",
         "combined-stream": "1.0.5",
         "mime-types": "2.1.17"
-      }
-    },
-    "formatio": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
-      "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
-      "dev": true,
-      "requires": {
-        "samsam": "1.3.0"
       }
     },
     "formidable": {
@@ -3726,12 +3679,6 @@
       "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
       "dev": true
     },
-    "jsmin": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/jsmin/-/jsmin-1.0.1.tgz",
-      "integrity": "sha1-570NzWSWw79IYyNb9GGj2YqjuYw=",
-      "dev": true
-    },
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
@@ -3808,26 +3755,6 @@
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
       "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
       "dev": true
-    },
-    "jxLoader": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jxLoader/-/jxLoader-0.1.1.tgz",
-      "integrity": "sha1-ATTqUUTlM7WU/B/yX/GU4jXFPs0=",
-      "dev": true,
-      "requires": {
-        "js-yaml": "0.3.7",
-        "moo-server": "1.3.0",
-        "promised-io": "0.3.5",
-        "walker": "1.0.7"
-      },
-      "dependencies": {
-        "js-yaml": {
-          "version": "0.3.7",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-0.3.7.tgz",
-          "integrity": "sha1-1znY7oZGHlSzVNan19HyrZoWf2I=",
-          "dev": true
-        }
-      }
     },
     "keygrip": {
       "version": "1.0.2",
@@ -4114,9 +4041,9 @@
       "dev": true
     },
     "lolex": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.0.tgz",
-      "integrity": "sha512-rPO6R1t8PjYL6xbsFUg7aByKkWAql907na6powPBORVs4DCm8aMBUkL4+6CXO0gEIV8vtu3mWV0FB8ZaCYPBmA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.2.tgz",
+      "integrity": "sha512-A5pN2tkFj7H0dGIAM6MFvHKMJcPnjZsOMvR7ujCjfgW5TbV6H9vb1PgxLtHvjqNZTHsUolz+6/WEO0N1xNx2ng==",
       "dev": true
     },
     "loose-envify": {
@@ -4136,15 +4063,6 @@
       "requires": {
         "pseudomap": "1.0.2",
         "yallist": "2.1.2"
-      }
-    },
-    "makeerror": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
-      "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
-      "dev": true,
-      "requires": {
-        "tmpl": "1.0.4"
       }
     },
     "media-typer": {
@@ -4318,12 +4236,6 @@
       "integrity": "sha1-VtoaLRy/AdOLfhr8McELz6GSkWc=",
       "optional": true
     },
-    "moo-server": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/moo-server/-/moo-server-1.3.0.tgz",
-      "integrity": "sha1-XceVaVZaENbv7VQ5SR5p0jkuWPE=",
-      "dev": true
-    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -4352,12 +4264,6 @@
       "integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY=",
       "optional": true
     },
-    "native-promise-only": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
-      "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE=",
-      "dev": true
-    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -4377,24 +4283,16 @@
       "dev": true
     },
     "nise": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-1.2.0.tgz",
-      "integrity": "sha512-q9jXh3UNsMV28KeqI43ILz5+c3l+RiNW8mhurEwCKckuHQbL+hTJIKKTiUlCPKlgQ/OukFvSnKB/Jk3+sFbkGA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.3.0.tgz",
+      "integrity": "sha512-U+Krdzhsw4losPP/Rij5UGTLQgS9gaWmXdRIbZQIQWVsUGDBo+N0m9mrY9CCEnmwssgswwydxLJUZtFfouC0gA==",
       "dev": true,
       "requires": {
-        "formatio": "1.2.0",
+        "@sinonjs/formatio": "2.0.0",
         "just-extend": "1.1.27",
-        "lolex": "1.6.0",
+        "lolex": "2.3.2",
         "path-to-regexp": "1.7.0",
         "text-encoding": "0.6.4"
-      },
-      "dependencies": {
-        "lolex": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
-          "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=",
-          "dev": true
-        }
       }
     },
     "node-uuid": {
@@ -6275,12 +6173,6 @@
       "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
       "dev": true
     },
-    "promised-io": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/promised-io/-/promised-io-0.3.5.tgz",
-      "integrity": "sha1-StIXuzZYvKrplGsXqGaOzYUeE1Y=",
-      "dev": true
-    },
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
@@ -6671,22 +6563,35 @@
       "dev": true
     },
     "sinon": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-3.3.0.tgz",
-      "integrity": "sha512-/flfGfIxIRXSvZBHJzIf3iAyGYkmMQq6SQjA0cx9SOuVuq+4ZPPO4LJtH1Ce0Lznax1KSG1U6Dad85wIcSW19w==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.4.2.tgz",
+      "integrity": "sha512-cpOHpnRyY3Dk9dTHBYMfVBB0HUCSKIpxW07X6OGW2NiYPovs4AkcL8Q8MzecbAROjbfRA9esJCmlZgikxDz7DA==",
       "dev": true,
       "requires": {
-        "build": "0.1.4",
+        "@sinonjs/formatio": "2.0.0",
         "diff": "3.2.0",
-        "formatio": "1.2.0",
         "lodash.get": "4.4.2",
-        "lolex": "2.3.0",
-        "native-promise-only": "0.8.1",
-        "nise": "1.2.0",
-        "path-to-regexp": "1.7.0",
-        "samsam": "1.3.0",
-        "text-encoding": "0.6.4",
+        "lolex": "2.3.2",
+        "nise": "1.3.0",
+        "supports-color": "5.2.0",
         "type-detect": "4.0.5"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+          "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
       }
     },
     "slash": {
@@ -6786,12 +6691,6 @@
           "dev": true
         }
       }
-    },
-    "stack-trace": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
-      "dev": true
     },
     "statuses": {
       "version": "1.4.0",
@@ -7011,12 +6910,6 @@
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
-    "timespan": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/timespan/-/timespan-2.3.0.tgz",
-      "integrity": "sha1-SQLOBAvRPYRcj1myfp1ZutbzmSk=",
-      "dev": true
-    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -7025,12 +6918,6 @@
       "requires": {
         "os-tmpdir": "1.0.2"
       }
-    },
-    "tmpl": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
-      "dev": true
     },
     "to-fast-properties": {
       "version": "1.0.3",
@@ -7111,27 +6998,6 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
-    "uglify-js": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.12.tgz",
-      "integrity": "sha512-4jxrTXlV0HaXTsNILfXW0eey7Qo8qHYM6ih5ZNh45erDWU2GHmKDmekwBTskDb12h+kdd2DBvdzqVb47YzNmTA==",
-      "requires": {
-        "commander": "2.14.1",
-        "source-map": "0.6.1"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.14.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
-          "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw=="
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-        }
-      }
-    },
     "urlgrey": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/urlgrey/-/urlgrey-0.4.4.tgz",
@@ -7194,15 +7060,6 @@
         }
       }
     },
-    "walker": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
-      "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
-      "dev": true,
-      "requires": {
-        "makeerror": "1.0.11"
-      }
-    },
     "which": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
@@ -7210,20 +7067,6 @@
       "dev": true,
       "requires": {
         "isexe": "2.0.0"
-      }
-    },
-    "winston": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.0.tgz",
-      "integrity": "sha1-gIBQuT1SZh7Z+2wms/DIJnCLCu4=",
-      "dev": true,
-      "requires": {
-        "async": "1.0.0",
-        "colors": "1.0.3",
-        "cycle": "1.0.3",
-        "eyes": "0.1.8",
-        "isstream": "0.1.2",
-        "stack-trace": "0.0.10"
       }
     },
     "wordwrap": {
@@ -7236,12 +7079,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-    },
-    "wrench": {
-      "version": "1.3.9",
-      "resolved": "https://registry.npmjs.org/wrench/-/wrench-1.3.9.tgz",
-      "integrity": "sha1-bxPsNRRTF+spLKX2UxORskQRFBE=",
-      "dev": true
     },
     "write": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "mocha": "^3.5.0",
     "mocha-eslint": "^4.1.0",
     "nyc": "^11.1.0",
-    "sinon": "^3.2.0",
+    "sinon": "^4.4.2",
     "supertest": "^3.0.0"
   },
   "dependencies": {
@@ -61,8 +61,7 @@
     "babel-runtime": "^6.25.0",
     "koa-router": "^7.2.1",
     "swatchjs": "^3.1.0",
-    "swatchjs-koa-middleware": "^0.0.2",
-    "uglify-js": "^3.3.12"
+    "swatchjs-koa-middleware": "^0.0.2"
   },
   "files": [
     "dist"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swatchjs-koa",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "KOA adapter for swatchjs",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
     "babel-runtime": "^6.25.0",
     "koa-router": "^7.2.1",
     "swatchjs": "^3.1.0",
-    "swatchjs-koa-middleware": "^0.0.2"
+    "swatchjs-koa-middleware": "^0.0.2",
+    "uglify-js": "^3.3.12"
   },
   "files": [
     "dist"


### PR DESCRIPTION
GitHub notes a vulnerability:

![screenshot 2018-03-01 15 33 35](https://user-images.githubusercontent.com/1891931/36875696-eeed1b1e-1d65-11e8-87ff-c92a2f331e51.png)

This PR fixes.

https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-8857
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-8858