### PR TITLE
Allow clients to pass custom correlationId

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,16 +200,21 @@ function sampleOnException(error) {
 
 Clients can use the [koa-bunyan-logger](https://www.npmjs.com/package/koa-bunyan-logger) package
 to configure a request logger for their service. That package exposes a `requestIdContext` function
-that will generate a unique ID for each request to be included in the output logs. The unique ID is
-saved on the KOA context object under a key you can specify with the `prop` parameter, with a
-default value of `reqId`. See that package documentation for details.
+that generates a unique ID for each request to correlate related log messages. The unique ID is
+saved on the KOA context object under a key you can override with the `prop` parameter (the default
+value is `reqId`. See that package documentation for details.)
 
-Currently, `swatchjs-koa` supports this request logger as a part of the `swatchCtx`. To provide
-additional debugging support, users can have the unique request ID included as a response header
-named `x-swatchjs-request-id`. To enable this header, set the `loggerRequestId` property in the
+The `swatchjs-koa` package uses this bunyan logger as a part of the `swatchCtx`. To provide
+additional debugging support, clients can request that the unique ID be returned in a response
+header: `x-swatch-request-id`. To enable this behavior, set the `loggerRequestId` property in the
 `swatchjs-koa` configuration to a string that matches the `prop` parameter passed into the
-`koa-bunyan-logger` configuration. This will allow `swatchjs-koa` to find the request ID parameter
-from the KOA context. If not set, the header will not be included in the response.
+`koa-bunyan-logger` configuration. This will allow `swatchjs-koa` to look up the request ID
+value from the KOA context. If not set, the header will not be included in the response.
+
+Additionally, if the `loggerRequestId` property is set in the `swatchjs-koa` configuration, the
+caller can choose to pass in their own request ID in the request headers. Simply make an API
+request to a swatch endpoint and pass in any value under the `x-swatch-request-id` header, and
+it will overwrite the bunyan logger request guid with the client guid to be included in all logs.
 
 ### Middleware
 

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,0 +1,8 @@
+const SUPPORTED_VERBS = ['get', 'post'];
+
+const REQUEST_ID_HEADER_NAME = 'x-swatch-request-id';
+
+module.exports = {
+  REQUEST_ID_HEADER_NAME,
+  SUPPORTED_VERBS,
+};

--- a/lib/context.js
+++ b/lib/context.js
@@ -1,7 +1,22 @@
+const constants = require('./constants');
+
 // Given the swatch configuration options, check for an
 //  `onException` handler and return a KOA-compliant middleware
 //   function that will init the swatch context and then await
 function init(options) {
+  // Check if user configured a custom 'requestIdProp'. If so, check the
+  //  request headers for a client-specified request guid, and if found,
+  //  override the KOA bunyan logger request id field with client value
+  function overrideClientRequestId(ctx) {
+    const prop = options.requestIdProp;
+    if (prop !== undefined) {
+      const clientRequestId = ctx.request.headers[constants.REQUEST_ID_HEADER_NAME];
+      if (clientRequestId !== undefined) {
+        ctx[prop] = clientRequestId;
+      }
+    }
+  }
+
   async function swatchCtxMiddleware(koaCtx, next) {
     // Create the swatchCtx object from the KOA ctx
     koaCtx.swatchCtx = {};
@@ -9,6 +24,7 @@ function init(options) {
     // Allow access to KOA ctx in case of emergency - Private
     koaCtx.swatchCtx.koaCtx = () => (koaCtx);
 
+    // Copy important properties from the KOA request context
     koaCtx.swatchCtx.req = {
       headers: Object.assign({}, koaCtx.request.headers),
       href: koaCtx.request.href,
@@ -21,9 +37,14 @@ function init(options) {
       secure: koaCtx.request.secure,
       url: koaCtx.request.url,
     };
+
+    // Set internal properties for Swatch request context
     koaCtx.swatchCtx.request = {
       onException: options.onException,
     };
+
+    // Optionally override the existing bunyan logger request id
+    overrideClientRequestId(koaCtx);
 
     // Continue chain of handlers
     await next();

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -1,8 +1,7 @@
 const middleware = require('swatchjs-koa-middleware');
 
+const constants = require('./constants');
 const response = require('./response');
-
-const SUPPORTED_VERBS = ['get', 'post'];
 
 function defaultVerbs(requested) {
   if (requested && !(requested instanceof Array)) {
@@ -18,7 +17,7 @@ function defaultVerbs(requested) {
     });
   }
 
-  return requested || SUPPORTED_VERBS;
+  return requested || constants.SUPPORTED_VERBS;
 }
 
 function defaultPrefix(prefix) {

--- a/lib/response.js
+++ b/lib/response.js
@@ -1,6 +1,6 @@
 const middleware = require('swatchjs-koa-middleware');
 
-const REQUEST_ID_HEADER_NAME = 'x-swatch-request-id';
+const constants = require('./constants');
 
 const { response } = middleware;
 
@@ -9,9 +9,9 @@ function responseHandler(fn, options) {
     // Decide whether to set the request id as response header
     const prop = options.requestIdProp;
     if (prop !== undefined) {
-      const correlationId = ctx[prop];
-      if (correlationId !== undefined) {
-        ctx.set(REQUEST_ID_HEADER_NAME, correlationId);
+      const requestId = ctx[prop];
+      if (requestId !== undefined) {
+        ctx.set(constants.REQUEST_ID_HEADER_NAME, requestId);
       }
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "swatchjs-koa",
-  "version": "2.1.5",
+  "version": "2.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -207,9 +207,9 @@
       }
     },
     "acorn": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.2.tgz",
-      "integrity": "sha512-cJrKCNcr2kv8dlDnbw+JPUGjHZzo4myaxOLmpOX8a+rgX94YeTcTMv/LFJUSByRpc+i4GgVnnhLxvMu/2Y+rqw==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+      "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
       "dev": true
     },
     "acorn-jsx": {
@@ -223,7 +223,7 @@
       "dependencies": {
         "acorn": {
           "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
           "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
           "dev": true
         }
@@ -472,6 +472,12 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         }
       }
     },
@@ -1153,6 +1159,12 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         }
       }
     },
@@ -1282,9 +1294,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30000882",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000882.tgz",
-      "integrity": "sha512-8rH1O4z9f2RWZkVPfjgjH7o91s+1S/bnw11akv8a2WK/vby9dHwvPIOPJndB9EOLhyLY+SN78MQ1lwRcQXiveg==",
+      "version": "1.0.30000885",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000885.tgz",
+      "integrity": "sha512-cXKbYwpxBLd7qHyej16JazPoUacqoVuDhvR61U7Fr5vSxMUiodzcYa1rQYRYfZ5GexV03vGZHd722vNPLjPJGQ==",
       "dev": true
     },
     "caseless": {
@@ -1387,13 +1399,14 @@
       "dev": true
     },
     "codecov": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/codecov/-/codecov-3.0.4.tgz",
-      "integrity": "sha512-KJyzHdg9B8U9LxXa7hS6jnEW5b1cNckLYc2YpnJ1nEFiOW+/iSzDHp+5MYEIQd9fN3/tC6WmGZmYiwxzkuGp/A==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/codecov/-/codecov-3.1.0.tgz",
+      "integrity": "sha512-aWQc/rtHbcWEQLka6WmBAOpV58J2TwyXqlpAQGhQaSiEUoigTTUk6lLd2vB3kXkhnDyzyH74RXfmV4dq2txmdA==",
       "dev": true,
       "requires": {
         "argv": "^0.0.2",
         "ignore-walk": "^3.0.1",
+        "js-yaml": "^3.12.0",
         "request": "^2.87.0",
         "urlgrey": "^0.4.4"
       }
@@ -1423,9 +1436,9 @@
       }
     },
     "commander": {
-      "version": "2.17.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-      "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.18.0.tgz",
+      "integrity": "sha512-6CYPa+JP2ftfRU2qkDK+UTVeQYosOg/2GbcjIcKPHfinyOLPVGXu/ovN86RP49Re5ndJK1N0kuiidFFuepc4ZQ==",
       "dev": true
     },
     "component-emitter": {
@@ -1470,10 +1483,13 @@
       "dev": true
     },
     "convert-source-map": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-      "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
-      "dev": true
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
+      "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.1"
+      }
     },
     "cookiejar": {
       "version": "2.1.2",
@@ -1482,12 +1498,12 @@
       "dev": true
     },
     "cookies": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.7.1.tgz",
-      "integrity": "sha1-fIphX1SBxhq58WyDNzG8uPZjuZs=",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.7.2.tgz",
+      "integrity": "sha512-J2JjH9T3PUNKPHknprxgCrCaZshIfxW2j49gq1E1CP5Micj1LppWAR2y9EHSQAzEiX84zOsScWNwUZ0b/ChlMw==",
       "dev": true,
       "requires": {
-        "depd": "~1.1.1",
+        "depd": "~1.1.2",
         "keygrip": "~1.0.2"
       }
     },
@@ -1518,7 +1534,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -1545,11 +1561,11 @@
       }
     },
     "debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+      "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
       "requires": {
-        "ms": "2.0.0"
+        "ms": "^2.1.1"
       }
     },
     "deep-eql": {
@@ -1680,9 +1696,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.62",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.62.tgz",
-      "integrity": "sha512-x09ndL/Gjnuk3unlAyoGyUg3wbs4w/bXurgL7wL913vXHAOWmMhrLf1VNGRaMLngmadd5Q8gsV9BFuIr6rP+Xg==",
+      "version": "1.3.65",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.65.tgz",
+      "integrity": "sha512-tyGr+wh2c/JYBVMeflKpZ3ricwtBPyVBMtRNxYGObl7TP5bAeupgz4VZnBzQSFleZViXYTws1yZtKKFQYZyiYw==",
       "dev": true
     },
     "error-ex": {
@@ -1738,7 +1754,7 @@
     },
     "eslint": {
       "version": "4.19.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
+      "resolved": "http://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
       "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
       "dev": true,
       "requires": {
@@ -1886,6 +1902,12 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         }
       }
     },
@@ -1907,13 +1929,19 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         }
       }
     },
     "eslint-plugin-babel": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-babel/-/eslint-plugin-babel-5.1.0.tgz",
-      "integrity": "sha512-HBkv9Q0LU/IhNUauC8TrbhcN79Yq/+xh2bYTOcv6KMaV2tsvVphkHwDTJ9r3C6mJUnmxrtzT3DQfrWj0rOISqQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-babel/-/eslint-plugin-babel-5.2.0.tgz",
+      "integrity": "sha512-9pNH/e214SN3r2nEwwTLRI27jUN4+nuLMv1+qxfDv8Za9cJ3F+aPkNinYiVeUmAmiEtOttbS32yuwRG2DREvJg==",
       "dev": true,
       "requires": {
         "eslint-rule-composer": "^0.3.0"
@@ -1945,6 +1973,12 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         }
       }
     },
@@ -2050,7 +2084,7 @@
     },
     "external-editor": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
       "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "dev": true,
       "requires": {
@@ -2954,33 +2988,19 @@
       "dev": true
     },
     "http-assert": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/http-assert/-/http-assert-1.3.0.tgz",
-      "integrity": "sha1-oxpc+IyHPsu1eWkH1NbxMujAHko=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/http-assert/-/http-assert-1.4.0.tgz",
+      "integrity": "sha512-tPVv62a6l3BbQoM/N5qo969l0OFxqpnQzNUPeYfTP6Spo4zkgWeDBD1D5thI7sDLg7jCCihXTLB0X8UtdyAy8A==",
       "dev": true,
       "requires": {
         "deep-equal": "~1.0.1",
-        "http-errors": "~1.6.1"
-      },
-      "dependencies": {
-        "http-errors": {
-          "version": "1.6.3",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-          "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
-          "dev": true,
-          "requires": {
-            "depd": "~1.1.2",
-            "inherits": "2.0.3",
-            "setprototypeof": "1.1.0",
-            "statuses": ">= 1.4.0 < 2"
-          }
-        }
+        "http-errors": "~1.7.1"
       }
     },
     "http-errors": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.0.tgz",
-      "integrity": "sha512-hz3BtSHB7Z6dNWzYc+gUbWqG4dIpJedwwOhe1cvGUq5tGmcTTIRkPiAbyh/JlZx+ksSJyGJlgcHo5jGahiXnKw==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.1.tgz",
+      "integrity": "sha512-jWEUgtZWGSMba9I1N3gc1HmvpBUaNC9vDdA46yScAdp+C5rdEuKWUBLWTQpW9FwSWSbYYs++b6SDCxf9UEJzfw==",
       "requires": {
         "depd": "~1.1.2",
         "inherits": "2.0.3",
@@ -3631,9 +3651,9 @@
       }
     },
     "koa": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/koa/-/koa-2.5.2.tgz",
-      "integrity": "sha512-MoVGWre9g3p35pCqXNhOT/a4trwK5CGvalIoPi7qOA2RCZaep3GCsa/G/tD9QMjQI7bmVWn3XF3SOau8RkPh6w==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/koa/-/koa-2.5.3.tgz",
+      "integrity": "sha512-U6rgy2kwlfO+3P1phAidDrRZpGfwcpHCxl33wFe+fHXalpzEshHGnMaSU7I/ZeDFpGRQkbQOYsXkXfUjn+AtdQ==",
       "dev": true,
       "requires": {
         "accepts": "^1.3.5",
@@ -3641,7 +3661,7 @@
         "content-disposition": "~0.5.2",
         "content-type": "^1.0.4",
         "cookies": "~0.7.1",
-        "debug": "^3.1.0",
+        "debug": "~3.1.0",
         "delegates": "^1.0.0",
         "depd": "^1.1.2",
         "destroy": "^1.0.4",
@@ -3662,10 +3682,25 @@
         "vary": "^1.1.2"
       },
       "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "koa-compose": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-4.1.0.tgz",
           "integrity": "sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
       }
@@ -3821,9 +3856,9 @@
       "dev": true
     },
     "lolex": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.1.tgz",
-      "integrity": "sha512-Oo2Si3RMKV3+lV5MsSWplDQFoTClz/24S0MMHYcgGWWmFXr6TMlqcqk/l1GtH+d5wLBwNRiqGnwDRMirtFalJw==",
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.4.tgz",
+      "integrity": "sha512-Gh6Vffq/piTeHwunLNFR1jFVaqlwK9GMNUxFcsO1cwHyvbRKHwX8UDkxmrDnbcPdHNmpv7z2kxtkkSx5xkNpMw==",
       "dev": true
     },
     "loose-envify": {
@@ -3922,7 +3957,7 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mkdirp": {
@@ -3954,9 +3989,18 @@
       "dependencies": {
         "commander": {
           "version": "2.15.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+          "resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
           "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
           "dev": true
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
         },
         "glob": {
           "version": "7.1.2",
@@ -3971,6 +4015,12 @@
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         },
         "supports-color": {
           "version": "5.4.0",
@@ -4001,9 +4051,9 @@
       "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
     },
     "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
     },
     "mute-stream": {
       "version": "0.0.7",
@@ -5598,7 +5648,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
@@ -5897,19 +5947,19 @@
       "dev": true
     },
     "sinon": {
-      "version": "6.1.5",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-6.1.5.tgz",
-      "integrity": "sha512-TcbRoWs1SdY6NOqfj0c9OEQquBoZH+qEf8799m1jjcbfWrrpyCQ3B/BpX7+NKa7Vn33Jl+Z50H4Oys3bzygK2Q==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-6.2.0.tgz",
+      "integrity": "sha512-gLFZz5UYvOhYzQ+DBzw/OCkmWaLAHlAyQiE2wxUOmAGVdasP9Yw93E+OwZ0UuhW3ReMu1FKniuNsL6VukvC77w==",
       "dev": true,
       "requires": {
-        "@sinonjs/commons": "^1.0.1",
+        "@sinonjs/commons": "^1.0.2",
         "@sinonjs/formatio": "^2.0.0",
         "@sinonjs/samsam": "^2.0.0",
         "diff": "^3.5.0",
         "lodash.get": "^4.4.2",
-        "lolex": "^2.7.1",
-        "nise": "^1.4.2",
-        "supports-color": "^5.4.0",
+        "lolex": "^2.7.2",
+        "nise": "^1.4.4",
+        "supports-color": "^5.5.0",
         "type-detect": "^4.0.8"
       },
       "dependencies": {
@@ -5981,9 +6031,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
-      "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.1.tgz",
+      "integrity": "sha512-TfOfPcYGBB5sDuPn3deByxPhmfegAhpDYKSOXZQN81Oyrrif8ZCodOLzK3AesELnCx03kikhyDwh0pfvvQvF8w==",
       "dev": true
     },
     "sprintf-js": {
@@ -6072,9 +6122,9 @@
       "dev": true
     },
     "superagent": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.2.tgz",
-      "integrity": "sha512-gVH4QfYHcY3P0f/BZzavLreHW3T1v7hG9B+hpMQotGQqurOvhv87GcMCd6LWySmBuf+BDR44TQd0aISjVHLeNQ==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
+      "integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
       "dev": true,
       "requires": {
         "component-emitter": "^1.2.0",
@@ -6082,21 +6132,21 @@
         "debug": "^3.1.0",
         "extend": "^3.0.0",
         "form-data": "^2.3.1",
-        "formidable": "^1.1.1",
+        "formidable": "^1.2.0",
         "methods": "^1.1.1",
         "mime": "^1.4.1",
         "qs": "^6.5.1",
-        "readable-stream": "^2.0.5"
+        "readable-stream": "^2.3.5"
       }
     },
     "supertest": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/supertest/-/supertest-3.1.0.tgz",
-      "integrity": "sha512-O44AMnmJqx294uJQjfUmEyYOg7d9mylNFsMw/Wkz4evKd1njyPrtCN+U6ZIC7sKtfEVQhfTqFFijlXx8KP/Czw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-3.3.0.tgz",
+      "integrity": "sha512-dMQSzYdaZRSANH5LL8kX3UpgK9G1LRh/jnggs/TI0W2Sz7rkMx9Y48uia3K9NgcaWEV28tYkBnXE4tiFC77ygQ==",
       "dev": true,
       "requires": {
-        "methods": "~1.1.2",
-        "superagent": "3.8.2"
+        "methods": "^1.1.2",
+        "superagent": "^3.8.3"
       }
     },
     "supports-color": {
@@ -6183,7 +6233,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
@@ -6388,7 +6438,7 @@
     },
     "yargs": {
       "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-1.2.6.tgz",
+      "resolved": "http://registry.npmjs.org/yargs/-/yargs-1.2.6.tgz",
       "integrity": "sha1-nHtKgv1dWVsr8Xq23MQxNUMv40s=",
       "dev": true,
       "requires": {
@@ -6397,7 +6447,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.1.0.tgz",
           "integrity": "sha1-md9lelJXTCHJBXSX33QnkLK0wN4=",
           "dev": true
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swatchjs-koa",
-  "version": "2.1.5",
+  "version": "2.2.0",
   "description": "KOA adapter for swatchjs",
   "main": "dist/index.js",
   "scripts": {

--- a/test/context.test.js
+++ b/test/context.test.js
@@ -1,17 +1,15 @@
 const { expect } = require('chai');
 
+const constants = require('../lib/constants');
 const context = require('../lib/context');
 
 describe('context', () => {
-  it('should initialize the swatchCtx', (done) => {
-    const exampleUrl = 'http://localhost:1234/some/path?name=test';
+  const requestIdProp = 'test-ctx-prop';
 
-    const options = {
-      onException: () => ('mapped_error'),
-    };
-    const fn = context.init(options);
+  const exampleUrl = 'http://localhost:1234/some/path?name=test';
 
-    const ctx = {
+  function createMockContext() {
+    return {
       request: {
         href: exampleUrl,
         host: 'localhost:1234',
@@ -25,21 +23,70 @@ describe('context', () => {
         url: exampleUrl,
       },
     };
+  }
+
+  function verifyResult(ctx) {
+    const error = ctx.swatchCtx.request.onException('error');
+    expect(error).to.equal('mapped_error');
+
+    expect(ctx.swatchCtx.req.href).to.equal(exampleUrl);
+    expect(ctx.swatchCtx.req.host).to.equal('localhost:1234');
+    expect(ctx.swatchCtx.req.method).to.equal('GET');
+    expect(ctx.swatchCtx.req.origin).to.equal('');
+    expect(ctx.swatchCtx.req.path).to.equal('some/path');
+    expect(ctx.swatchCtx.req.protocol).to.equal('http');
+    expect(ctx.swatchCtx.req.query).to.equal('?name=test');
+    expect(ctx.swatchCtx.req.secure).to.equal(false);
+    expect(ctx.swatchCtx.req.url).to.equal(exampleUrl);
+
+    expect(ctx.swatchCtx.req.headers.authorization).to.equal('value');
+  }
+
+  it('should initialize the swatchCtx without a custom request id', (done) => {
+    const options = {
+      onException: () => ('mapped_error'),
+    };
+    const fn = context.init(options);
+
+    const ctx = createMockContext();
     fn(ctx, () => {}).then(() => {
-      const error = ctx.swatchCtx.request.onException('error');
-      expect(error).to.equal('mapped_error');
+      verifyResult(ctx);
+      expect(ctx[requestIdProp]).to.equal(undefined);
 
-      expect(ctx.swatchCtx.req.href).to.equal(exampleUrl);
-      expect(ctx.swatchCtx.req.host).to.equal('localhost:1234');
-      expect(ctx.swatchCtx.req.method).to.equal('GET');
-      expect(ctx.swatchCtx.req.origin).to.equal('');
-      expect(ctx.swatchCtx.req.path).to.equal('some/path');
-      expect(ctx.swatchCtx.req.protocol).to.equal('http');
-      expect(ctx.swatchCtx.req.query).to.equal('?name=test');
-      expect(ctx.swatchCtx.req.secure).to.equal(false);
-      expect(ctx.swatchCtx.req.url).to.equal(exampleUrl);
+      done();
+    }).catch(done);
+  });
 
-      expect(ctx.swatchCtx.req.headers.authorization).to.equal('value');
+  it('should initialize the swatchCtx with custom request id but no value', (done) => {
+    const options = {
+      onException: () => ('mapped_error'),
+      requestIdProp,
+    };
+    const fn = context.init(options);
+
+    const ctx = createMockContext();
+
+    fn(ctx, () => {}).then(() => {
+      verifyResult(ctx);
+      expect(ctx[requestIdProp]).to.equal(undefined);
+
+      done();
+    }).catch(done);
+  });
+
+  it('should initialize the swatchCtx with a custom request id', (done) => {
+    const options = {
+      onException: () => ('mapped_error'),
+      requestIdProp,
+    };
+    const fn = context.init(options);
+
+    const ctx = createMockContext();
+    ctx.request.headers[constants.REQUEST_ID_HEADER_NAME] = 'test-header-guid';
+
+    fn(ctx, () => {}).then(() => {
+      verifyResult(ctx);
+      expect(ctx[requestIdProp]).to.equal('test-header-guid');
 
       done();
     }).catch(done);

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,4 +1,4 @@
 --require babel-polyfill
---compilers js:babel-core/register
+--require babel-core/register
 --recursive
 --timeout 5000

--- a/test/response.test.js
+++ b/test/response.test.js
@@ -35,7 +35,7 @@ describe('response', () => {
   it('should handle success response with no request ID', () => {
     // Try to find a koa request id or a client request id but none exist
     //  In this case we should not try to set a response header with a value
-    const ctx = initCtx(() => {}));
+    const ctx = initCtx(() => {});
     const result = {
       name: 'test',
       value: 'value',


### PR DESCRIPTION
Currently the swatch ctx supports a request correlationId as set by the KOA bunyan logger package, and lets swatch-clients have that correlationId returned as a response header.

Recently received a feature request to allow callers to pass in their own correlationId in a request header, which would help link requests handled by a swatch-based service with other services in a chain, so updating the package here to check for a client-specified guid and overwrite the bunyan logger request guid at the start of a request before returning it again in the response header